### PR TITLE
Open data transfers sessions in ftps client with an ssl socket

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -261,12 +261,7 @@ public class FTPSClient extends FTPClient {
     protected void sslNegotiation() throws IOException {
         plainSocket = _socket_;
         initSslContext();
-
-        SSLSocketFactory ssf = context.getSocketFactory();
-        String host = (_hostname_ != null) ? _hostname_ : getRemoteAddress().getHostAddress();
-        int port = _socket_.getPort();
-        SSLSocket socket =
-            (SSLSocket) ssf.createSocket(_socket_, host, port, false);
+        SSLSocket socket = (SSLSocket)createSSLSocket(_socket_);
         socket.setEnableSessionCreation(isCreation);
         socket.setUseClientMode(isClientMode);
 
@@ -296,7 +291,7 @@ public class FTPSClient extends FTPClient {
                 socket.getOutputStream(), getControlEncoding()));
 
         if (isClientMode) {
-            if (hostnameVerifier != null && !hostnameVerifier.verify(host, socket.getSession())) {
+            if (hostnameVerifier != null && !hostnameVerifier.verify(socket.getInetAddress().getHostAddress(), socket.getSession())) {
                 throw new SSLHandshakeException("Hostname doesn't match certificate");
             }
         }
@@ -625,6 +620,7 @@ public class FTPSClient extends FTPClient {
     protected Socket _openDataConnection_(String command, String arg)
             throws IOException {
         Socket socket = super._openDataConnection_(command, arg);
+        socket = createSSLSocket(socket);
         _prepareDataSocket_(socket);
         if (socket instanceof SSLSocket) {
             SSLSocket sslSocket = (SSLSocket)socket;
@@ -898,6 +894,18 @@ public class FTPSClient extends FTPClient {
         }
         // N.B. Cannot use trim before substring as leading space would affect the offset.
         return reply.substring(idx+prefix.length()).trim();
+    }
+
+    /**
+     * Create SSL socket from plain socket.
+     *
+     * @param socket
+     * @return
+     * @throws IOException
+     */
+    private Socket createSSLSocket(Socket socket) throws IOException {
+        SSLSocketFactory f = context.getSocketFactory();
+        return f.createSocket(socket, socket.getInetAddress().getHostAddress(), socket.getPort(), false);
     }
 
     // DEPRECATED - for API compatibility only - DO NOT USE

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -904,8 +904,12 @@ public class FTPSClient extends FTPClient {
      * @throws IOException
      */
     private Socket createSSLSocket(Socket socket) throws IOException {
-        SSLSocketFactory f = context.getSocketFactory();
-        return f.createSocket(socket, socket.getInetAddress().getHostAddress(), socket.getPort(), false);
+        if (socket != null) {
+            SSLSocketFactory f = context.getSocketFactory();
+            return f.createSocket(socket, socket.getInetAddress().getHostAddress(), socket.getPort(), false);
+        } else {
+            return null;
+        }
     }
 
     // DEPRECATED - for API compatibility only - DO NOT USE


### PR DESCRIPTION
FTPS data transfers were failing due to the use of a plain socket for the data transfer. I changed it to use an ssl socket, and the data transfer issues were resolved.
