### PR TITLE
[NET-663] Retrieve socket host before closing if remote verification …

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPClient.java
@@ -937,10 +937,13 @@ implements Configurable
 
         if (__remoteVerificationEnabled && !verifyRemote(socket))
         {
+            // Grab the host before we close the socket to avoid NET-663
+            InetAddress socketHost = socket.getInetAddress();
+
             socket.close();
 
             throw new IOException(
-                    "Host attempting data connection " + socket.getInetAddress().getHostAddress() +
+                    "Host attempting data connection " + socketHost.getHostAddress() +
                     " is not same as server " + getRemoteAddress().getHostAddress());
         }
 


### PR DESCRIPTION
…fails

This retrieves the socket host before closing the socket
when remote verification fails. In NET-663, socket.getInetAddress()
returned a null after the socket was closed, causing a
NullPointerException instead of the more helpful error message intended.