### PR TITLE
NET-685: change default connect timeout

### DIFF
--- a/src/main/java/org/apache/commons/net/SocketClient.java
+++ b/src/main/java/org/apache/commons/net/SocketClient.java
@@ -99,7 +99,7 @@ public abstract class SocketClient
     protected ServerSocketFactory _serverSocketFactory_;
 
     /** The socket's connect timeout (0 = infinite timeout) */
-    private static final int DEFAULT_CONNECT_TIMEOUT = 0;
+    private static final int DEFAULT_CONNECT_TIMEOUT = 60000;
     protected int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
     /** Hint for SO_RCVBUF size */


### PR DESCRIPTION
I changed the socket **DEFAULT_CONNECT_TIMEOUT** value, because, if the server doesn't reply and I don't set the connection timeout, the method _FTPClient.connect()_ hangs infinitely, blocking the whole JVM.

This happens in the multi-threading environment.

Even though there exist the method _setConnectTimeout()_ to set the timeout for Socket, I think a default value should be set-up in order to avoid production breakdown.

Thanks to everybody.
Simone