### PR TITLE
NET-687: Removed creation of SSL socket when opening data connection …

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -620,7 +620,6 @@ public class FTPSClient extends FTPClient {
     protected Socket _openDataConnection_(String command, String arg)
             throws IOException {
         Socket socket = super._openDataConnection_(command, arg);
-        socket = createSSLSocket(socket);
         _prepareDataSocket_(socket);
         if (socket instanceof SSLSocket) {
             SSLSocket sslSocket = (SSLSocket)socket;


### PR DESCRIPTION
…since this is already handled by the socket factory

See Jira ticket for full explanation:
[https://issues.apache.org/jira/browse/NET-687](https://issues.apache.org/jira/browse/NET-687)
