### PR TITLE
NET-690 Performance issue when using the FTPClient to retrieve files from z/OS and z/VM

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPClient.java
@@ -1917,6 +1917,7 @@ implements Configurable
             Util.copyStream(input, local, getBufferSize(),
                     CopyStreamEvent.UNKNOWN_STREAM_SIZE, mergeListeners(csl),
                     false);
+            input.close();                    
 
             // Get the transfer response
             return completePendingCommand();


### PR DESCRIPTION
Looks like the inputstream needs closing before attempting to get the response from the control channel. 