### PR TITLE
Explicitly set socket timeout in FTPSClient for implicit mode to avoid infinite hang

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -216,6 +216,9 @@ public class FTPSClient extends FTPClient {
     protected void _connectAction_() throws IOException {
         // Implicit mode.
         if (isImplicit) {
+            // Set the socket timeout to avoid an indefinite hang in startHandshake()
+            // We can't call super._connectAction_() yet because we're not connected
+            _socket_.setSoTimeout(_timeout_);
             sslNegotiation();
         }
         super._connectAction_();


### PR DESCRIPTION
This solves a problem we have with a well-known FTPS provider hanging on TLS handshake. Currently, if the implicit mode is used, the socket timeout isn't set until super._connectAction() works its way up the chain _after_ sslNegotation(). There is no way to avoid a potentially infinite hang in the handshake. This explicitly sets the timeout that would _eventually_ be set by SocketClient._connectAction_().

There may be a more logical or cleaner way of doing this, but I'm not that familiar with this code.