### PR TITLE
adding inclusiveHostCount as constructor parameter of SubnetUtils

### DIFF
--- a/src/main/java/org/apache/commons/net/util/SubnetUtils.java
+++ b/src/main/java/org/apache/commons/net/util/SubnetUtils.java
@@ -332,6 +332,33 @@ public class SubnetUtils {
     }
 
     /**
+     * Constructor that takes a CIDR-notation string, e.g. "192.168.0.1/16", a dotted decimal mask and and flag to
+     * return value of {@link SubnetInfo#getAddressCount()}
+     * @param cidrNotation A CIDR-notation string, e.g. "192.168.0.1/16"
+     * @param inclusiveHostCount A boolean value e.g. true
+     * @throws IllegalArgumentException if the parameter is invalid,
+     * i.e. does not match n.n.n.n/m where n=1-3 decimal digits, m = 1-2 decimal digits in range 0-32
+     */
+    public SubnetUtils(final String cidrNotation, final boolean inclusiveHostCount) {
+        this(cidrNotation);
+        this.inclusiveHostCount = inclusiveHostCount;
+    }
+
+    /**
+     * Constructor that takes a dotted decimal address, a dotted decimal mask and and flag to
+     * return value of {@link SubnetInfo#getAddressCount()}
+     * @param address An IP address, e.g. "192.168.0.1"
+     * @param mask A dotted decimal netmask e.g. "255.255.0.0"
+     * @param inclusiveHostCount A boolean value e.g. true
+     * @throws IllegalArgumentException if the address or mask is invalid,
+     * i.e. does not match n.n.n.n where n=1-3 decimal digits and the mask is not all zeros
+     */
+    public SubnetUtils(final String address, final String mask, final boolean inclusiveHostCount) {
+        this(address, mask);
+        this.inclusiveHostCount = inclusiveHostCount;
+    }
+
+    /**
      * Return a {@link SubnetInfo} instance that contains subnet-specific statistics
      * @return new instance
      */

--- a/src/test/java/org/apache/commons/net/SubnetUtilsTest.java
+++ b/src/test/java/org/apache/commons/net/SubnetUtilsTest.java
@@ -400,4 +400,18 @@ public class SubnetUtilsTest extends TestCase {
         final SubnetUtils snu = new SubnetUtils("0.0.0.0/0");
         assertNotNull(snu);
     }
+
+    public void testInclusiveHostCountConstructors() {
+        final SubnetUtils snu = new SubnetUtils("172.16.32.200/32", true);
+        assertEquals(true, snu.isInclusiveHostCount());
+
+        final SubnetUtils subnetUtilsWithMaskParam = new SubnetUtils("172.16.32.200", "255.255.0.0", true);
+        assertEquals(true, subnetUtilsWithMaskParam.isInclusiveHostCount());
+
+        final SubnetUtils snuWithFalseInclusiveCount = new SubnetUtils("172.16.32.200/32", false);
+        assertEquals(false, snuWithFalseInclusiveCount.isInclusiveHostCount());
+
+        final SubnetUtils subnetUtilsWithMaskParamWithFalseInclusiveCount = new SubnetUtils("172.16.32.200", "255.255.0.0", false);
+        assertEquals(false, subnetUtilsWithMaskParamWithFalseInclusiveCount.isInclusiveHostCount());
+    }
 }


### PR DESCRIPTION
`SubnetUtils` classes is right now initialised with `inclusiveHostCount`  as false by default.
Generally we are either interested into inclusiveHostCount being false or true since the inception of use case. We do not change it after the object of `SubnetUtils` have been created.

Also if `inclusiveHostCount` is supported as constructor parameters, it makes the use case of `inclusiveHostCount` more verbose. Otherwise it is very difficult for new person to find out what if such a parameter exist let alone default behaviour of it being false.

This pr adds constructors which support `inclusiveHostCount` as constructor parameters.