### PR TITLE
(doc) Fix Maven Central badge version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Apache Commons Net
 [![Travis-CI Status](https://travis-ci.org/apache/commons-net.svg)](https://travis-ci.org/apache/commons-net)
 [![GitHub Actions Status](https://github.com/apache/commons-net/workflows/Java%20CI/badge.svg)](https://github.com/apache/commons-net/actions)
 [![Coverage Status](https://coveralls.io/repos/apache/commons-net/badge.svg)](https://coveralls.io/r/apache/commons-net)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/commons-net/commons-net/badge.svg)](https://maven-badges.herokuapp.com/maven-central/commons-net/commons-net/)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/commons-net/commons-net/badge.svg?gav=true)](https://maven-badges.herokuapp.com/maven-central/commons-net/commons-net/)
 [![Javadocs](https://javadoc.io/badge/commons-net/commons-net/3.8.0.svg)](https://javadoc.io/doc/commons-net/commons-net/3.8.0)
 
 Apache Commons Net library contains a collection of network utilities and protocol implementations.


### PR DESCRIPTION
Fixes the [badge](https://github.com/softwaremill/maven-badges) version in the README.md to ignore the non-semver historical version.