### PR TITLE
Fixing proxy-problems in _parsePassiveModeReply

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPClient.java
@@ -853,8 +853,6 @@ public class FTPClient extends FTP implements Configurable {
             }
         } else if (_socket_ == null) {
             pasvHost = null; // For unit testing.
-        } else {
-            pasvHost = _socket_.getInetAddress().getHostAddress();
         }
         this.passiveHost = pasvHost;
         this.passivePort = pasvPort;


### PR DESCRIPTION
FTPClient in passive mode didn't worked, when using a proxy, cause the FTPClient tried to open a data-connection to the proxy-host instead the real passive-host. This was caused, cause the passiveHost was ALWAYS overwritten by the socket-address (wich is the address of the proxy-host, when using a proxy). The passive-host should ALWAYS be parsed from the pasvResponse and only be overwritten, when the pasvResponse is a "look lie IP address" (0,0,0,0).