### PR TITLE
NET-650 Delegate host resolution to Socket.connect()

### DIFF
--- a/src/main/java/org/apache/commons/net/SocketClient.java
+++ b/src/main/java/org/apache/commons/net/SocketClient.java
@@ -71,6 +71,9 @@ public abstract class SocketClient {
     /** The hostname used for the connection (null = no hostname supplied). */
     protected String _hostname_;
 
+    /** The remote socket address used for the connection */
+    protected InetSocketAddress _remoteAddress_;
+
     /** The default port the client should connect to. */
     protected int _defaultPort_;
 
@@ -118,7 +121,8 @@ public abstract class SocketClient {
     }
 
     // helper method to allow code to be shared with connect(String,...) methods
-    private void _connect(final InetAddress host, final int port, final InetAddress localAddr, final int localPort) throws SocketException, IOException {
+    private void _connect(final InetSocketAddress remoteAddress, final InetAddress localAddr, final int localPort) throws IOException {
+        _remoteAddress_ = remoteAddress;
         _socket_ = _socketFactory_.createSocket();
         if (receiveBufferSize != -1) {
             _socket_.setReceiveBufferSize(receiveBufferSize);
@@ -129,7 +133,7 @@ public abstract class SocketClient {
         if (localAddr != null) {
             _socket_.bind(new InetSocketAddress(localAddr, localPort));
         }
-        _socket_.connect(new InetSocketAddress(host, port), connectTimeout);
+        _socket_.connect(remoteAddress, connectTimeout);
         _connectAction_();
     }
 
@@ -218,7 +222,7 @@ public abstract class SocketClient {
      */
     public void connect(final InetAddress host, final int port) throws SocketException, IOException {
         _hostname_ = null;
-        _connect(host, port, null, -1);
+        _connect(new InetSocketAddress(host, port), null, -1);
     }
 
     /**
@@ -235,7 +239,7 @@ public abstract class SocketClient {
      */
     public void connect(final InetAddress host, final int port, final InetAddress localAddr, final int localPort) throws SocketException, IOException {
         _hostname_ = null;
-        _connect(host, port, localAddr, localPort);
+        _connect(new InetSocketAddress(host, port), localAddr, localPort);
     }
 
     /**
@@ -264,8 +268,7 @@ public abstract class SocketClient {
      * @throws java.net.UnknownHostException If the hostname cannot be resolved.
      */
     public void connect(final String hostname, final int port) throws SocketException, IOException {
-        _hostname_ = hostname;
-        _connect(InetAddress.getByName(hostname), port, null, -1);
+        connect(hostname, port, null, -1);
     }
 
     /**
@@ -283,7 +286,7 @@ public abstract class SocketClient {
      */
     public void connect(final String hostname, final int port, final InetAddress localAddr, final int localPort) throws SocketException, IOException {
         _hostname_ = hostname;
-        _connect(InetAddress.getByName(hostname), port, localAddr, localPort);
+        _connect(new InetSocketAddress(hostname, port), localAddr, localPort);
     }
 
     /**

--- a/src/test/java/org/apache/commons/net/SocketClientTest.java
+++ b/src/test/java/org/apache/commons/net/SocketClientTest.java
@@ -16,25 +16,37 @@
  */
 package org.apache.commons.net;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.UnknownHostException;
 
 import org.apache.commons.net.ftp.FTPClient;
+import org.junit.jupiter.api.Test;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A simple test class for SocketClient settings.
  *
  * @since 3.2
  */
-public class SocketClientTest extends TestCase {
+public class SocketClientTest {
     private static final String PROXY_HOST = "127.0.0.1";
     private static final int PROXY_PORT = 1080;
+
+    private static final String LOCALHOST_ADDRESS = "127.0.0.1";
+    private static final String UNRESOLVED_HOST = "unresolved";
+    private static final int REMOTE_PORT = 21;
 
     /**
      * A simple test to verify that the Proxy is being set.
      */
+    @Test
     public void testProxySettings() {
         final SocketClient socketClient = new FTPClient();
         assertNull(socketClient.getProxy());
@@ -42,5 +54,27 @@ public class SocketClientTest extends TestCase {
         socketClient.setProxy(proxy);
         assertEquals(proxy, socketClient.getProxy());
         assertFalse(socketClient.isConnected());
+    }
+
+    @Test
+    public void testConnectResolved() {
+        final SocketClient socketClient = new FTPClient();
+
+        assertThrows(IOException.class, () -> socketClient.connect(LOCALHOST_ADDRESS, REMOTE_PORT));
+        final InetSocketAddress remoteAddress = socketClient._remoteAddress_;
+        assertFalse(remoteAddress.isUnresolved());
+        assertEquals(LOCALHOST_ADDRESS, remoteAddress.getHostString());
+        assertEquals(REMOTE_PORT, remoteAddress.getPort());
+    }
+
+    @Test
+    public void testConnectUnresolved() {
+        final SocketClient socketClient = new FTPClient();
+
+        assertThrows(UnknownHostException.class, () -> socketClient.connect(UNRESOLVED_HOST, REMOTE_PORT, null, -1));
+        final InetSocketAddress remoteAddress = socketClient._remoteAddress_;
+        assertTrue(remoteAddress.isUnresolved());
+        assertEquals(UNRESOLVED_HOST, remoteAddress.getHostString());
+        assertEquals(REMOTE_PORT, remoteAddress.getPort());
     }
 }


### PR DESCRIPTION
This pull request presents a solution of [NET-650](https://issues.apache.org/jira/browse/NET-650), delegating remote host resolution to `java.net.Socket.connect()` instead of performing host resolution earlier in `org.apache.commons.net.SocketClient.connect()` methods.

For `SocketClient.connect()` methods that accept a `String` value for the `hostname` argument, the existing implementation calls `InetAddress.getByName(hostname)`, performing host resolution prior to calling `Socket.connect()`. This works for use cases where the remote host DNS address is resolvable, but does not work for scenarios where the remote host must be resolved through a proxy server.

The `new InetSocketAddress(String hostname, int port)` constructor attempts name resolution, but catches the `UnknownHostException` and allows the hostname to remain unresolved. This behavior allows custom Java `SocketFactory` implementations to pass the unresolved hostname to a remote proxy server, where name resolution may succeed, allowing the connection to proceed.

Changing the `SocketClient.connect()` methods to construct an `InetSocketAddress` should support existing standard behavior while also supporting additional use cases like proxy-based name resolution.

The pull request includes a new `_remoteAddress_` member in `SocketClient`, which supports new unit test methods that check the status of `InetSocketAddress.isUnresolved()` after expecting particular exceptions.