### PR TITLE
Fixes many grammar issues and typos in JavaDoc and code comments

### DIFF
--- a/src/main/java/org/apache/commons/net/PrintCommandListener.java
+++ b/src/main/java/org/apache/commons/net/PrintCommandListener.java
@@ -21,7 +21,7 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 
 /**
- * This is a support class for some of the example programs. It is a sample implementation of the ProtocolCommandListener interface which just prints out to a
+ * This is a support class for some example programs. It is a sample implementation of the ProtocolCommandListener interface which just prints out to a
  * specified stream all command/reply traffic.
  *
  * @since 2.0

--- a/src/main/java/org/apache/commons/net/ProtocolCommandEvent.java
+++ b/src/main/java/org/apache/commons/net/ProtocolCommandEvent.java
@@ -38,7 +38,7 @@ public class ProtocolCommandEvent extends EventObject {
 
     /**
      * Creates a ProtocolCommandEvent signalling a reply to a command was received. ProtocolCommandEvents created with this constructor should only be sent
-     * after a complete command reply has been received fromt a server.
+     * after a complete command reply has been received from a server.
      *
      * @param source    The source of the event.
      * @param replyCode The integer code indicating the natureof the reply. This will be the protocol integer value for protocols that use integer reply codes,

--- a/src/main/java/org/apache/commons/net/SocketClient.java
+++ b/src/main/java/org/apache/commons/net/SocketClient.java
@@ -139,7 +139,7 @@ public abstract class SocketClient {
 
     /**
      * Because there are so many connect() methods, the _connectAction_() method is provided as a means of performing some action immediately after establishing
-     * a connection, rather than reimplementing all of the connect() methods. The last action performed by every connect() method after opening a socket is to
+     * a connection, rather than reimplementing all the connect() methods. The last action performed by every connect() method after opening a socket is to
      * call this method.
      * <p>
      * This method sets the timeout on the just opened socket to the default timeout set by {@link #setDefaultTimeout setDefaultTimeout() }, sets _input_ and
@@ -353,7 +353,7 @@ public abstract class SocketClient {
      *
      * @return the charset.
      * @since 3.3
-     * @deprecated Since the code now requires Java 1.6 as a mininmum
+     * @deprecated Since the code now requires Java 1.6 as a minimum
      */
     @Deprecated
     public String getCharsetName() {
@@ -361,7 +361,7 @@ public abstract class SocketClient {
     }
 
     /**
-     * Subclasses can override this if they need to provide their own instance field for backwards compatibilty.
+     * Subclasses can override this if they need to provide their own instance field for backwards compatibility.
      *
      * @return the CommandSupport instance, may be {@code null}
      * @since 3.0
@@ -632,7 +632,7 @@ public abstract class SocketClient {
 
     /**
      * Set the default timeout in milliseconds to use when opening a socket. This value is only used previous to a call to {@link #connect connect()} and should
-     * not be confused with {@link #setSoTimeout setSoTimeout()} which operates on an the currently opened socket. _timeout_ contains the new timeout value.
+     * not be confused with {@link #setSoTimeout setSoTimeout()} which operates on the currently opened socket. _timeout_ contains the new timeout value.
      *
      * @param timeout The timeout in milliseconds to use for the socket connection.
      */
@@ -721,7 +721,7 @@ public abstract class SocketClient {
      * Sets the SO_LINGER timeout on the currently opened socket.
      *
      * @param on  True if linger is to be enabled, false if not.
-     * @param val The linger timeout (in hundredths of a second?)
+     * @param val The {@code linger} timeout (in hundredths of a second?)
      * @throws SocketException      If the operation fails.
      * @throws NullPointerException if the socket is not currently open
      */
@@ -754,7 +754,7 @@ public abstract class SocketClient {
     }
 
     /**
-     * Verifies that the remote end of the given socket is connected to the the same host that the SocketClient is currently connected to. This is useful for
+     * Verifies that the remote end of the given socket is connected to the same host that the SocketClient is currently connected to. This is useful for
      * doing a quick security check when a client needs to accept a connection from a server, such as an FTP data connection or a BSD R command standard error
      * stream.
      *

--- a/src/main/java/org/apache/commons/net/bsd/RCommandClient.java
+++ b/src/main/java/org/apache/commons/net/bsd/RCommandClient.java
@@ -40,13 +40,13 @@ import org.apache.commons.net.io.SocketInputStream;
  * the RCommandClient class if the process runs as root. However, there is no such restriction on Windows95 and some other systems. The security risks are
  * obvious. However, when carefully used, rcmd() can be very useful when used behind a firewall.
  * <p>
- * As with virtually all of the client classes in org.apache.commons.net, this class derives from SocketClient. But it overrides most of its connection methods
+ * As with virtually all the client classes in org.apache.commons.net, this class derives from SocketClient. But it overrides most of its connection methods
  * so that the local Socket will originate from an acceptable rshell port. The way to use RCommandClient is to first connect to the server, call the
  * {@link #rcommand rcommand() } method, and then fetch the connection's input, output, and optionally error streams. Interaction with the remote command is
  * controlled entirely through the I/O streams. Once you have finished processing the streams, you should invoke
  * {@link org.apache.commons.net.bsd.RExecClient#disconnect disconnect() } to clean up properly.
  * <p>
- * By default the standard output and standard error streams of the remote process are transmitted over the same connection, readable from the input stream
+ * By default, the standard output and standard error streams of the remote process are transmitted over the same connection, readable from the input stream
  * returned by {@link org.apache.commons.net.bsd.RExecClient#getInputStream getInputStream() } . However, it is possible to tell the rshd daemon to return the
  * standard error stream over a separate connection, readable from the input stream returned by {@link org.apache.commons.net.bsd.RExecClient#getErrorStream
  * getErrorStream() } . You can specify that a separate connection should be created for standard error by setting the boolean
@@ -65,12 +65,12 @@ public class RCommandClient extends RExecClient {
     public static final int DEFAULT_PORT = 514;
 
     /**
-     * The smallest port number an rcmd client may use. By BSD convention this number is 512.
+     * The smallest port number a rcmd client may use. By BSD convention this number is 512.
      */
     public static final int MIN_CLIENT_PORT = 512;
 
     /**
-     * The largest port number an rcmd client may use. By BSD convention this number is 1023.
+     * The largest port number a rcmd client may use. By BSD convention this number is 1023.
      */
     public static final int MAX_CLIENT_PORT = 1023;
 
@@ -267,7 +267,7 @@ public class RCommandClient extends RExecClient {
     /**
      * Remotely executes a command through the rshd daemon on the server to which the RCommandClient is connected. After calling this method, you may interact
      * with the remote process through its standard input, output, and error streams. You will typically be able to detect the termination of the remote process
-     * after reaching end of file on its standard output (accessible through {@link #getInputStream getInputStream() }. Disconnecting from the server or closing
+     * after reaching end of file on its standard output (accessible through {@link #getInputStream getInputStream()}). Disconnecting from the server or closing
      * the process streams before reaching end of file will not necessarily terminate the remote process.
      * <p>
      * If a separate error stream is requested, the remote server will connect to a local socket opened by RCommandClient, providing an independent stream

--- a/src/main/java/org/apache/commons/net/bsd/RExecClient.java
+++ b/src/main/java/org/apache/commons/net/bsd/RExecClient.java
@@ -33,12 +33,12 @@ import org.apache.commons.net.util.NetConstants;
  * only when the rexecd daemon is configured to run, which is a rarity these days because of the security risks involved. However, rexec() can be very useful
  * for performing administrative tasks on a network behind a firewall.
  * <p>
- * As with virtually all of the client classes in org.apache.commons.net, this class derives from SocketClient, inheriting its connection methods. The way to
+ * As with virtually all the client classes in org.apache.commons.net, this class derives from SocketClient, inheriting its connection methods. The way to
  * use RExecClient is to first connect to the server, call the {@link #rexec rexec()} method, and then fetch the connection's input, output, and optionally
  * error streams. Interaction with the remote command is controlled entirely through the I/O streams. Once you have finished processing the streams, you should
  * invoke {@link #disconnect disconnect()} to clean up properly.
  * <p>
- * By default the standard output and standard error streams of the remote process are transmitted over the same connection, readable from the input stream
+ * By default, the standard output and standard error streams of the remote process are transmitted over the same connection, readable from the input stream
  * returned by {@link #getInputStream getInputStream()}. However, it is possible to tell the rexecd daemon to return the standard error stream over a separate
  * connection, readable from the input stream returned by {@link #getErrorStream getErrorStream()}. You can specify that a separate connection should be created
  * for standard error by setting the boolean <code> separateErrorStream </code> parameter of {@link #rexec rexec()} to <code> true </code>. The standard input
@@ -99,7 +99,7 @@ public class RExecClient extends SocketClient {
     /**
      * Disconnects from the server, closing all associated open sockets and streams.
      *
-     * @throws IOException If there an error occurs while disconnecting.
+     * @throws IOException If an error occurs while disconnecting.
      */
     @Override
     public void disconnect() throws IOException {
@@ -154,7 +154,7 @@ public class RExecClient extends SocketClient {
     /**
      * Same as <code> rexec(username, password, command, false); </code>
      *
-     * @param username the user name
+     * @param username the username
      * @param password the password
      * @param command  the command to run
      * @throws IOException if an error occurs
@@ -166,7 +166,7 @@ public class RExecClient extends SocketClient {
     /**
      * Remotely executes a command through the rexecd daemon on the server to which the RExecClient is connected. After calling this method, you may interact
      * with the remote process through its standard input, output, and error streams. You will typically be able to detect the termination of the remote process
-     * after reaching end of file on its standard output (accessible through {@link #getInputStream getInputStream() }. Disconnecting from the server or closing
+     * after reaching end of file on its standard output (accessible through {@link #getInputStream getInputStream()}). Disconnecting from the server or closing
      * the process streams before reaching end of file will not necessarily terminate the remote process.
      * <p>
      * If a separate error stream is requested, the remote server will connect to a local socket opened by RExecClient, providing an independent stream through

--- a/src/main/java/org/apache/commons/net/bsd/RLoginClient.java
+++ b/src/main/java/org/apache/commons/net/bsd/RLoginClient.java
@@ -21,11 +21,11 @@ import java.io.IOException;
 
 /**
  * RLoginClient is very similar to {@link org.apache.commons.net.bsd.RCommandClient}, from which it is derived, and uses the rcmd() facility implemented in
- * RCommandClient to implement the functionality of the rlogin command that first appeared in 4.2BSD Unix. rlogin is a command used to login to a remote machine
- * from a trusted host, sometimes without issuing a password. The trust relationship is the same as described in the documentation for
+ * RCommandClient to implement the functionality of the rlogin command that first appeared in 4.2BSD Unix. rlogin is a command used to log in to a
+ * remote machine from a trusted host, sometimes without issuing a password. The trust relationship is the same as described in the documentation for
  * {@link org.apache.commons.net.bsd.RCommandClient}.
  * <p>
- * As with virtually all of the client classes in org.apache.commons.net, this class derives from SocketClient. But it relies on the connection methods defined
+ * As with virtually all the client classes in org.apache.commons.net, this class derives from SocketClient. But it relies on the connection methods defined
  * in RcommandClient which ensure that the local Socket will originate from an acceptable rshell port. The way to use RLoginClient is to first connect to the
  * server, call the {@link #rlogin rlogin() } method, and then fetch the connection's input and output streams. Interaction with the remote command is
  * controlled entirely through the I/O streams. Once you have finished processing the streams, you should invoke
@@ -72,13 +72,13 @@ public class RLoginClient extends RCommandClient {
      * Logins into a remote machine through the rlogind daemon on the server to which the RLoginClient is connected. After calling this method, you may interact
      * with the remote login shell through its standard input and output streams. Standard error is sent over the same stream as standard output. You will
      * typically be able to detect the termination of the remote login shell after reaching end of file on its standard output (accessible through
-     * {@link #getInputStream getInputStream() }. Disconnecting from the server or closing the process streams before reaching end of file will terminate the
+     * {@link #getInputStream getInputStream()}). Disconnecting from the server or closing the process streams before reaching end of file will terminate the
      * remote login shell in most cases.
      * <p>
      * If user authentication fails, the rlogind daemon will request that a password be entered interactively. You will be able to read the prompt from the
      * output stream of the RLoginClient and write the password to the input stream of the RLoginClient.
      *
-     * @param localUsername  The user account on the local machine that is trying to login to the remote host.
+     * @param localUsername  The user account on the local machine that is trying to log in to the remote host.
      * @param remoteUsername The account name on the server that is being logged in to.
      * @param terminalType   The name of the user's terminal (e.g., "vt100", "network", etc.)
      * @param terminalSpeed  The speed of the user's terminal, expressed as a baud rate or bps (e.g., 9600 or 38400)

--- a/src/main/java/org/apache/commons/net/chargen/CharGenTCPClient.java
+++ b/src/main/java/org/apache/commons/net/chargen/CharGenTCPClient.java
@@ -24,7 +24,7 @@ import org.apache.commons.net.SocketClient;
 /**
  * The CharGenTCPClient class is a TCP implementation of a client for the character generator protocol described in RFC 864. It can also be used for Systat (RFC
  * 866), Quote of the Day (RFC 865), and netstat (port 15). All of these protocols involve connecting to the appropriate port, and reading data from an input
- * stream. The chargen protocol actually sends data until the receiving end closes the connection. All of the others send only a fixed amount of data and then
+ * stream. The chargen protocol actually sends data until the receiving end closes the connection. All the others send only a fixed amount of data and then
  * close the connection.
  * <p>
  * To use the CharGenTCPClient class, just establish a connection with {@link org.apache.commons.net.SocketClient#connect connect } and call

--- a/src/main/java/org/apache/commons/net/chargen/CharGenUDPClient.java
+++ b/src/main/java/org/apache/commons/net/chargen/CharGenUDPClient.java
@@ -27,7 +27,7 @@ import org.apache.commons.net.util.NetConstants;
 /**
  * The CharGenUDPClient class is a UDP implementation of a client for the character generator protocol described in RFC 864. It can also be used for Systat (RFC
  * 866), Quote of the Day (RFC 865), and netstat (port 15). All of these protocols involve sending a datagram to the appropriate port, and reading data
- * contained in one or more reply datagrams. The chargen and quote of the day protocols only send one reply datagram containing 512 bytes or less of data. The
+ * contained in one or more reply datagrams. The chargen and quote of the day protocols only send one reply datagram containing 512 bytes or fewer. The
  * other protocols may reply with more than one datagram, in which case you must wait for a timeout to determine that all reply datagrams have been sent.
  * <p>
  * To use the CharGenUDPClient class, just open a local UDP port with {@link org.apache.commons.net.DatagramSocketClient#open open } and call {@link #send send
@@ -66,7 +66,7 @@ public final class CharGenUDPClient extends DatagramSocketClient {
     }
 
     /**
-     * Receive the reply data from the server. This will always be 512 bytes or less. Chargen and quote of the day only return one packet. Netstat and systat
+     * Receive the reply data from the server. This will always be 512 bytes or fewer. Chargen and quote of the day only return one packet. Netstat and systat
      * require multiple calls to receive() with timeout detection.
      *
      * @return The reply data from the server.

--- a/src/main/java/org/apache/commons/net/examples/ftp/FTPClientExample.java
+++ b/src/main/java/org/apache/commons/net/examples/ftp/FTPClientExample.java
@@ -340,7 +340,7 @@ public final class FTPClientExample {
             if (binaryTransfer) {
                 ftp.setFileType(FTP.BINARY_FILE_TYPE);
             } else {
-                // in theory this should not be necessary as servers should default to ASCII
+                // in theory this should not be necessary as servers should default to ASCII,
                 // but they don't all do so - see NET-500
                 ftp.setFileType(FTP.ASCII_FILE_TYPE);
             }

--- a/src/main/java/org/apache/commons/net/examples/ftp/TFTPExample.java
+++ b/src/main/java/org/apache/commons/net/examples/ftp/TFTPExample.java
@@ -30,7 +30,7 @@ import org.apache.commons.net.tftp.TFTPClient;
 import org.apache.commons.net.tftp.TFTPPacket;
 
 /**
- * This is an example of a simple Java tftp client. Notice how all of the code is really just argument processing and error handling.
+ * This is an example of a simple Java tftp client. Notice how all the code is really just argument processing and error handling.
  * <p>
  * Usage: tftp [options] hostname localfile remotefile hostname - The name of the remote host, with optional :port localfile - The name of the local file to
  * send or the name to use for the received file remotefile - The name of the remote file to receive or the name for the remote server to use to name the local

--- a/src/main/java/org/apache/commons/net/examples/mail/IMAPExportMbox.java
+++ b/src/main/java/org/apache/commons/net/examples/mail/IMAPExportMbox.java
@@ -74,7 +74,7 @@ import org.apache.commons.net.imap.IMAPReply;
  * The sequence-set is passed unmodified to the FETCH command.<br>
  * The item names are wrapped in parentheses if more than one is provided. Otherwise, the parameter is assumed to be wrapped if necessary.<br>
  * Parameters with spaces must be quoted otherwise the OS shell will normally treat them as separate parameters.<br>
- * Also the listener that writes the mailbox only captures the multi-line responses (e.g. ones that include BODY references). It does not capture the output
+ * Also, the listener that writes the mailbox only captures the multi-line responses (e.g. ones that include BODY references). It does not capture the output
  * from FETCH commands using item names such as ENVELOPE or FLAGS that return a single line response.
  */
 public final class IMAPExportMbox {

--- a/src/main/java/org/apache/commons/net/examples/mail/IMAPImportMbox.java
+++ b/src/main/java/org/apache/commons/net/examples/mail/IMAPImportMbox.java
@@ -195,7 +195,7 @@ public final class IMAPImportMbox {
      * Is the message wanted?
      *
      * @param msgNum   the message number
-     * @param line     the From line
+     * @param line     the {@code From} line
      * @param msgNums  the list of wanted message numbers
      * @param contains the list of strings to be contained
      * @return true if the message is wanted

--- a/src/main/java/org/apache/commons/net/examples/mail/POP3ExportMbox.java
+++ b/src/main/java/org/apache/commons/net/examples/mail/POP3ExportMbox.java
@@ -37,8 +37,8 @@ import org.apache.commons.net.pop3.POP3SClient;
  * file.
  * <p>
  * The code currently assumes that POP3Client decodes the POP3 data as iso-8859-1. The POP3 standard only allows for ASCII so in theory iso-8859-1 should be OK.
- * However it appears that actual POP3 implementations may return 8bit data that is outside the ASCII range; this may result in loss of data when the mailbox is
- * created.
+ * However, it appears that actual POP3 implementations may return 8bit data that is outside the ASCII range; this may result in loss of data when the mailbox
+ * is created.
  * <p>
  * See main() method for usage details
  */

--- a/src/main/java/org/apache/commons/net/examples/mail/POP3Mail.java
+++ b/src/main/java/org/apache/commons/net/examples/mail/POP3Mail.java
@@ -29,7 +29,7 @@ import org.apache.commons.net.pop3.POP3SClient;
 
 /**
  * This is an example program demonstrating how to use the POP3[S]Client class. This program connects to a POP3[S] server and retrieves the message headers of
- * all the messages, printing the From: and Subject: header entries for each message.
+ * all the messages, printing the {@code From:} and {@code Subject:} header entries for each message.
  * <p>
  * See main() method for usage details
  */

--- a/src/main/java/org/apache/commons/net/examples/telnet/TelnetClientExample.java
+++ b/src/main/java/org/apache/commons/net/examples/telnet/TelnetClientExample.java
@@ -234,7 +234,7 @@ public class TelnetClientExample implements Runnable, TelnetNotificationHandler 
     }
 
     /**
-     * Reader thread. Reads lines from the TelnetClient and echoes them on the screen.
+     * Reader thread: Reads lines from the TelnetClient and echoes them on the screen.
      */
     @Override
     public void run() {

--- a/src/main/java/org/apache/commons/net/examples/unix/rlogin.java
+++ b/src/main/java/org/apache/commons/net/examples/unix/rlogin.java
@@ -25,14 +25,14 @@ import org.apache.commons.net.examples.util.IOUtil;
 /**
  * This is an example program demonstrating how to use the RLoginClient class. This program connects to an rlogin daemon and begins to interactively read input
  * from stdin (this will be line buffered on most systems, so don't expect character at a time interactivity), passing it to the remote login process and
- * writing the remote stdout and stderr to local stdout. If you don't have .rhosts or hosts.equiv files set up, the rlogin daemon will prompt you for a
- * password.
+ * writing the remote stdout and stderr to local stdout. If you don't have {@code .rhosts} or {@code hosts.equiv} files set up, the rlogin daemon will prompt
+ * you for a password.
  * <p>
  * On Unix systems you will not be able to use the rshell capability unless the process runs as root since only root can bind port addresses lower than 1024.
  * <p>
  * JVM's using green threads will likely have problems if the rlogin daemon requests a password. This program is merely a demonstration and is not suitable for
- * use as an application, especially given that it relies on line buffered input from System.in. The best way to run this example is probably from a Win95 dos
- * box into a Unix host.
+ * use as an application, especially given that it relies on line-buffered input from System.in. The best way to run this example is probably from a Windows
+ * DOS box into a Unix host.
  * <p>
  * Example: java rlogin myhost localusername remoteusername vt100
  * <p>

--- a/src/main/java/org/apache/commons/net/ftp/FTP.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTP.java
@@ -54,7 +54,7 @@ import org.apache.commons.net.util.NetConstants;
  * before the more general <code> IOException </code> catch block. When you encounter an {@link org.apache.commons.net.ftp.FTPConnectionClosedException} , you
  * must disconnect the connection with {@link #disconnect disconnect() } to properly clean up the system resources used by FTP. Before disconnecting, you may
  * check the last reply code and text with {@link #getReplyCode getReplyCode }, {@link #getReplyString getReplyString }, and {@link #getReplyStrings
- * getReplyStrings}. You may avoid server disconnections while the client is idle by periodicaly sending NOOP commands to the server.
+ * getReplyStrings}. You may avoid server disconnections while the client is idle by periodically sending NOOP commands to the server.
  * <p>
  * Rather than list it separately for each method, we mention here that every method communicating with the server and throwing an IOException can also throw a
  * {@link org.apache.commons.net.MalformedServerReplyException} , which is a subclass of IOException. A MalformedServerReplyException will be thrown when the
@@ -79,7 +79,7 @@ public class FTP extends SocketClient {
     public static final int ASCII_FILE_TYPE = 0;
 
     /**
-     * A constant used to indicate the file(s) being transferred should be treated as EBCDIC. Note however that there are several different EBCDIC formats. All
+     * A constant used to indicate the file(s) being transferred should be treated as EBCDIC. Note however that there are several EBCDIC formats. All
      * constants ending in <code>FILE_TYPE</code> are used to indicate file types.
      */
     public static final int EBCDIC_FILE_TYPE = 1;
@@ -150,7 +150,7 @@ public class FTP extends SocketClient {
      */
     public static final int COMPRESSED_TRANSFER_MODE = 12;
 
-    // We have to ensure that the protocol communication is in ASCII
+    // We have to ensure that the protocol communication is in ASCII,
     // but we use ISO-8859-1 just in case 8-bit characters cross
     // the wire.
     /**
@@ -181,7 +181,7 @@ public class FTP extends SocketClient {
     protected boolean strictMultilineParsing;
 
     /**
-     * If this is true, then non-multiline replies must have the format: 3 digit code <space> <text> If false, then the 3 digit code does not have to be
+     * If this is true, then non-multiline replies must have the format: 3-digit code <space> <text> If false, then the 3-digit code does not have to be
      * followed by space See section 4.2 of RFC 959 for details.
      */
     private boolean strictReplyParsing = true;
@@ -230,7 +230,7 @@ public class FTP extends SocketClient {
     protected void __noop() throws IOException {
         final String msg = buildMessage(FTPCmd.NOOP.getCommand(), null);
         send(msg);
-        __getReplyNoReport(); // This may timeout
+        __getReplyNoReport(); // This may time out
     }
 
     /**
@@ -721,8 +721,8 @@ public class FTP extends SocketClient {
     /**
      * Return whether strict non-multiline parsing is enabled, as per RFC 959, section 4.2.
      * <p>
-     * The default is true, which requires the 3 digit code be followed by space and some text. <br>
-     * If false, only the 3 digit code is required (as was the case for versions up to 3.5) <br>
+     * The default is true, which requires the 3-digit code be followed by space and some text. <br>
+     * If false, only the 3-digit code is required (as was the case for versions up to 3.5) <br>
      *
      * @return True if strict (default), false if additional checks are not made
      * @since 3.6
@@ -1247,8 +1247,8 @@ public class FTP extends SocketClient {
     /**
      * Set strict non-multiline parsing.
      * <p>
-     * If true, it requires the 3 digit code be followed by space and some text. <br>
-     * If false, only the 3 digit code is required (as was the case for versions up to 3.5)
+     * If true, it requires the 3-digit code be followed by space and some text. <br>
+     * If false, only the 3-digit code is required (as was the case for versions up to 3.5)
      * <p>
      * <b>This should not be required by a well-behaved FTP server</b> <br>
      *
@@ -1426,7 +1426,7 @@ public class FTP extends SocketClient {
      * A convenience method to send the FTP TYPE command for text files to the server, receive the reply, and return the reply code.
      *
      * @param fileType         The type of the file (one of the <code>FILE_TYPE</code> constants).
-     * @param formatOrByteSize The format of the file (one of the <code>_FORMAT</code> constants. In the case of <code>LOCAL_FILE_TYPE</code>, the byte size.
+     * @param formatOrByteSize The format of the file (one of the <code>_FORMAT</code> constants). In the case of <code>LOCAL_FILE_TYPE</code>, the byte size.
      * @return The reply code received from the server.
      * @throws FTPConnectionClosedException If the FTP server prematurely closes the connection as a result of the client being idle or some other reason
      *                                      causing the server to send FTP reply code 421. This exception may be caught either as an IOException or

--- a/src/main/java/org/apache/commons/net/ftp/FTPClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPClient.java
@@ -444,8 +444,9 @@ public class FTPClient extends FTP implements Configurable {
     /**
      * Parse the pathname from a CWD reply.
      * <p>
-     * According to RFC959 (http://www.ietf.org/rfc/rfc959.txt), it should be the same as for MKD i.e. {@code 257<space>"<directory-name>"[<space>commentary]}
-     * where any double-quotes in {@code <directory-name>} are doubled. Unlike MKD, the commentary is optional.
+     * According to <a href="http://www.ietf.org/rfc/rfc959.txt">RFC959</a>, it should be the same as for MKD i.e.
+     * {@code 257<space>"<directory-name>"[<space>commentary]} where any double-quotes in {@code <directory-name>} are doubled.
+     * Unlike MKD, the commentary is optional.
      * <p>
      * However, see NET-442 for an exception.
      *
@@ -1408,7 +1409,7 @@ public class FTPClient extends FTP implements Configurable {
     }
 
     /**
-     * Queries the server for a supported feature, and returns the its value (if any). Caches the parsed response to avoid resending the command repeatedly.
+     * Queries the server for a supported feature, and returns its value (if any). Caches the parsed response to avoid resending the command repeatedly.
      *
      * @param feature the feature to check
      *
@@ -1560,7 +1561,7 @@ public class FTPClient extends FTP implements Configurable {
      * <p>
      * <b>For debug use only</b>
      * <p>
-     * Currently contains:
+     * Currently, it contains:
      * <ul>
      * <li>successfully acked NOOPs at end of transfer</li>
      * <li>unanswered NOOPs at end of transfer</li>
@@ -1577,9 +1578,9 @@ public class FTPClient extends FTP implements Configurable {
     }
 
     /**
-     * Returns the current data connection mode (one of the <code> _DATA_CONNECTION_MODE </code> constants.
+     * Returns the current data connection mode (one of the <code> _DATA_CONNECTION_MODE </code> constants).
      *
-     * @return The current data connection mode (one of the <code> _DATA_CONNECTION_MODE </code> constants.
+     * @return The current data connection mode (one of the <code> _DATA_CONNECTION_MODE </code> constants).
      */
     public int getDataConnectionMode() {
         return dataConnectionMode;
@@ -1922,10 +1923,10 @@ public class FTPClient extends FTP implements Configurable {
             // Don't create map here, because next line may throw exception
             final int replyCode = feat();
             if (replyCode == FTPReply.NOT_LOGGED_IN) { // 503
-                return false; // NET-518; don't create empy map
+                return false; // NET-518; don't create empty map
             }
             final boolean success = FTPReply.isPositiveCompletion(replyCode);
-            // we init the map here, so we don't keep trying if we know the command will fail
+            // init the map here, so we don't keep trying if we know the command will fail
             featuresMap = new HashMap<>();
             if (!success) {
                 return false;
@@ -2143,9 +2144,9 @@ public class FTPClient extends FTP implements Configurable {
     }
 
     /**
-     * Whether should attempt to use EPSV with IPv4. Default (if not set) is <code>false</code>
+     * Whether to attempt using EPSV with IPv4. Default (if not set) is <code>false</code>
      *
-     * @return true if should attempt EPSV
+     * @return true if EPSV shall be attempted with IPv4.
      * @since 2.2
      */
     public boolean isUseEPSVwithIPv4() {
@@ -2287,7 +2288,7 @@ public class FTPClient extends FTP implements Configurable {
      *
      * @param pathname the initial path, may be null
      * @param filter   the filter, non-null
-     * @return the list of FTPFile entries.
+     * @return the array of FTPFile entries.
      * @throws IOException on error
      * @since 2.2
      */
@@ -2397,7 +2398,7 @@ public class FTPClient extends FTP implements Configurable {
             return true;
         }
 
-        // If we get here, we either have an error code, or an intermmediate
+        // If we get here, we either have an error code, or an intermediate
         // reply requesting password.
         if (!FTPReply.isPositiveIntermediate(_replyCode)) {
             return false;
@@ -2426,7 +2427,7 @@ public class FTPClient extends FTP implements Configurable {
             return true;
         }
 
-        // If we get here, we either have an error code, or an intermmediate
+        // If we get here, we either have an error code, or an intermediate
         // reply requesting password.
         if (!FTPReply.isPositiveIntermediate(_replyCode)) {
             return false;
@@ -3077,7 +3078,7 @@ public class FTPClient extends FTP implements Configurable {
      * <b>N.B.</b> currently calling any connect method will reset the type to FTP.ASCII_FILE_TYPE and the formatOrByteSize to FTP.NON_PRINT_TEXT_FORMAT.
      *
      * @param fileType         The <code> _FILE_TYPE </code> constant indicating the type of file.
-     * @param formatOrByteSize The format of the file (one of the <code>_FORMAT</code> constants. In the case of <code>LOCAL_FILE_TYPE</code>, the byte size.
+     * @param formatOrByteSize The format of the file (one of the <code>_FORMAT</code> constants). In the case of <code>LOCAL_FILE_TYPE</code>, the byte size.
      *
      * @return True if successfully completed, false if not.
      * @throws FTPConnectionClosedException If the FTP server prematurely closes the connection as a result of the client being idle or some other reason
@@ -3111,7 +3112,7 @@ public class FTPClient extends FTP implements Configurable {
 
     /**
      * You can set this to true if you would like to get hidden files when {@link #listFiles} too. A <code>LIST -a</code> will be issued to the ftp server. It
-     * depends on your ftp server if you need to call this method, also dont expect to get rid of hidden files if you call this method with "false".
+     * depends on your ftp server if you need to call this method, also don't expect to get rid of hidden files if you call this method with "false".
      *
      * @param listHiddenFiles true if hidden files should be listed
      * @since 2.0

--- a/src/main/java/org/apache/commons/net/ftp/FTPClientConfig.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPClientConfig.java
@@ -125,7 +125,7 @@ import java.util.TreeMap;
 public class FTPClientConfig {
 
     /**
-     * Identifier by which a unix-based ftp server is known throughout the commons-net ftp system.
+     * Identifier by which a Unix-based ftp server is known throughout the commons-net ftp system.
      */
     public static final String SYST_UNIX = "UNIX";
 
@@ -178,7 +178,7 @@ public class FTPClientConfig {
     public static final String SYST_L8 = "TYPE: L8";
 
     /**
-     * Identifier by which an Netware-based ftp server is known throughout the commons-net ftp system.
+     * Identifier by which a Netware-based ftp server is known throughout the commons-net ftp system.
      *
      * @since 1.5
      */
@@ -235,7 +235,7 @@ public class FTPClientConfig {
 
     /**
      * Returns a Collection of all the language codes currently supported by this class. See {@link #setServerLanguageCode(String) serverLanguageCode} for a
-     * functional descrption of language codes within this system.
+     * functional description of language codes within this system.
      *
      * @return a Collection of all the language codes currently supported by this class
      */
@@ -322,7 +322,7 @@ public class FTPClientConfig {
      * The main constructor for an FTPClientConfig object
      *
      * @param systemKey key representing system type of the server being connected to. See {@link #getServerSystemKey() serverSystemKey} If set to the empty
-     *                  string, then FTPClient uses the system type returned by the server. However this is not recommended for general use; the correct system
+     *                  string, then FTPClient uses the system type returned by the server. However, this is not recommended for general use; the correct system
      *                  type should be set if it is known.
      */
     public FTPClientConfig(final String systemKey) {
@@ -546,10 +546,10 @@ public class FTPClientConfig {
      * </p>
      * <p>
      * If the code supplied is not supported here, <code>en_US</code> month names will be used. We are supporting here those language codes which, when a
-     * <code> java.util.Locale</code> is constucted using it, and a <code>java.text.SimpleDateFormat</code> is constructed using that Locale, the array returned
-     * by the SimpleDateFormat's <code>getShortMonths()</code> method consists solely of three 8-bit ASCII character strings. Additionally, languages which do
-     * not meet this requirement are included if a common alternative set of short month names is known to be used. This means that users who can tell us of
-     * additional such encodings may get them added to the list of supported languages by contacting the Apache Commons Net team.
+     * <code> java.util.Locale</code> is constructed using it, and a <code>java.text.SimpleDateFormat</code> is constructed using that Locale, the array
+     * returned by the SimpleDateFormat's <code>getShortMonths()</code> method consists solely of three 8-bit ASCII character strings. Additionally, languages
+     * which do not meet this requirement are included if a common alternative set of short month names is known to be used. This means that users who can tell
+     * us of additional such encodings may get them added to the list of supported languages by contacting the Apache Commons Net team.
      * </p>
      * <p>
      * <strong> Please note that this attribute will NOT be used to determine a locale-based date format for the language. </strong> Experience has shown that

--- a/src/main/java/org/apache/commons/net/ftp/FTPFile.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPFile.java
@@ -132,7 +132,7 @@ public class FTPFile implements Serializable {
     }
 
     /**
-     * If the FTPFile is a symbolic link, this method returns the name of the file being pointed to by the symbolic link. Otherwise it returns null.
+     * If the FTPFile is a symbolic link, this method returns the name of the file being pointed to by the symbolic link. Otherwise, it returns null.
      *
      * @return The file pointed to by the symbolic link (null if the FTPFile is not a symbolic link).
      */
@@ -259,7 +259,7 @@ public class FTPFile implements Serializable {
     /**
      * Tests whether an entry is valid or not. If the entry is invalid, only the {@link #getRawListing()} method will be useful. Other methods may fail.
      *
-     * Used in conjunction with list parsing that preseverves entries that failed to parse.
+     * Used in conjunction with list parsing that preserves entries that failed to parse.
      *
      * @see FTPClientConfig#setUnparseableEntries(boolean)
      * @return true if the entry is valid

--- a/src/main/java/org/apache/commons/net/ftp/FTPHTTPClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPHTTPClient.java
@@ -77,7 +77,7 @@ public class FTPHTTPClient extends FTPClient {
      *
      * @param proxyHost the hostname to use
      * @param proxyPort the port to use
-     * @param proxyUser the user name for the proxy
+     * @param proxyUser the username for the proxy
      * @param proxyPass the password for the proxy
      */
     public FTPHTTPClient(final String proxyHost, final int proxyPort, final String proxyUser, final String proxyPass) {
@@ -89,7 +89,7 @@ public class FTPHTTPClient extends FTPClient {
      *
      * @param proxyHost the hostname to use
      * @param proxyPort the port to use
-     * @param proxyUser the user name for the proxy
+     * @param proxyUser the username for the proxy
      * @param proxyPass the password for the proxy
      * @param encoding  the encoding to use
      */

--- a/src/main/java/org/apache/commons/net/ftp/FTPListParseEngine.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPListParseEngine.java
@@ -33,7 +33,7 @@ import org.apache.commons.net.util.Charsets;
  * <p>
  * This object defines a two-part parsing mechanism.
  * <p>
- * The first part is comprised of reading the raw input into an internal list of strings. Every item in this list corresponds to an actual file. All extraneous
+ * The first part consists of reading the raw input into an internal list of strings. Every item in this list corresponds to an actual file. All extraneous
  * matter emitted by the server will have been removed by the end of this phase. This is accomplished in conjunction with the FTPFileEntryParser associated with
  * this engine, by calling its methods <code>readNextEntry()</code> - which handles the issue of what delimits one entry from another, usually but not always a
  * line feed and <code>preParse()</code> - which handles removal of extraneous matter such as the preliminary lines of a listing, removal of duplicates on
@@ -102,14 +102,14 @@ public class FTPListParseEngine {
      * @return a list of FTPFile objects containing the whole list of files returned by the server as read by this object's parser.
      *         <p>
      *         <b> NOTE:</b> This array may contain null members if any of the individual file listings failed to parse. The caller should check each entry for
-     *         null before referencing it, or use the a filter such as {@link FTPFileFilters#NON_NULL} which does not allow null entries.
+     *         null before referencing it, or use a filter such as {@link FTPFileFilters#NON_NULL} which does not allow null entries.
      * @since 3.9.0
      */
     public List<FTPFile> getFileList(final FTPFileFilter filter) {
         return entries.stream().map(e -> {
             final FTPFile file = parser.parseFTPEntry(e);
             return file == null && saveUnparseableEntries ? new FTPFile(e) : file;
-        }).filter(file -> filter.accept(file)).collect(Collectors.toList());
+        }).filter(filter::accept).collect(Collectors.toList());
     }
 
     /**
@@ -133,7 +133,7 @@ public class FTPListParseEngine {
      * @return an array of FTPFile objects containing the whole list of files returned by the server as read by this object's parser.
      *         <p>
      *         <b> NOTE:</b> This array may contain null members if any of the individual file listings failed to parse. The caller should check each entry for
-     *         null before referencing it, or use the a filter such as {@link FTPFileFilters#NON_NULL} which does not allow null entries.
+     *         null before referencing it, or use a filter such as {@link FTPFileFilters#NON_NULL} which does not allow null entries.
      * @since 2.2
      * @throws IOException - not ever thrown, may be removed in a later release
      */
@@ -144,7 +144,7 @@ public class FTPListParseEngine {
 
     /**
      * Returns an array of at most <code>quantityRequested</code> FTPFile objects starting at this object's internal iterator's current position. If fewer than
-     * <code>quantityRequested</code> such elements are available, the returned array will have a length equal to the number of entries at and after after the
+     * <code>quantityRequested</code> such elements are available, the returned array will have a length equal to the number of entries at and after the
      * current position. If no such entries are found, this array will have a length of 0.
      *
      * After this method is called this object's internal iterator is advanced by a number of positions equal to the size of the array returned.
@@ -178,7 +178,7 @@ public class FTPListParseEngine {
      * back toward the beginning.
      *
      * If fewer than <code>quantityRequested</code> such elements are available, the returned array will have a length equal to the number of entries at and
-     * after after the current position. If no such entries are found, this array will have a length of 0.
+     * after the current position. If no such entries are found, this array will have a length of 0.
      *
      * After this method is called this object's internal iterator is moved back by a number of positions equal to the size of the array returned.
      *

--- a/src/main/java/org/apache/commons/net/ftp/FTPReply.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPReply.java
@@ -131,7 +131,7 @@ public final class FTPReply {
 
     /**
      * Determine if a reply code is a positive intermediate response. All codes beginning with a 3 are positive intermediate responses. The FTP server will send
-     * a positive intermediate response on the successful completion of one part of a multi-part sequence of commands. For example, after a successful USER
+     * a positive intermediate response on the successful completion of one part of a multipart sequence of commands. For example, after a successful USER
      * command, a positive intermediate response will be sent to indicate that the server is ready for the PASS command.
      *
      * @param reply The reply code to test.
@@ -144,7 +144,7 @@ public final class FTPReply {
     /**
      * Determine if a reply code is a positive preliminary response. All codes beginning with a 1 are positive preliminary responses. Postitive preliminary
      * responses are used to indicate tentative success. No further commands can be issued to the FTP server after a positive preliminary response until a
-     * follow up response is received from the server.
+     * follow-up response is received from the server.
      *
      * @param reply The reply code to test.
      * @return True if a reply code is a positive preliminary response, false if not.

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -179,7 +179,7 @@ public class FTPSClient extends FTPClient {
     }
 
     /**
-     * Constructor for FTPSClient, using explict mode, calls {@link #FTPSClient(String, boolean)}.
+     * Constructor for FTPSClient, using explicit mode, calls {@link #FTPSClient(String, boolean)}.
      *
      * @param protocol the protocol to use
      */
@@ -204,9 +204,9 @@ public class FTPSClient extends FTPClient {
 
     /**
      * Because there are so many connect() methods, the _connectAction_() method is provided as a means of performing some action immediately after establishing
-     * a connection, rather than reimplementing all of the connect() methods.
+     * a connection, rather than reimplementing all the connect() methods.
      *
-     * @throws IOException If it throw by _connectAction_.
+     * @throws IOException If there is any problem with establishing the connection.
      * @see org.apache.commons.net.SocketClient#_connectAction_()
      */
     @Override
@@ -375,7 +375,7 @@ public class FTPSClient extends FTPClient {
     /**
      * AUTH command.
      *
-     * @throws SSLException If it server reply code not equal "234" and "334".
+     * @throws SSLException If the server reply code equals neither "234" nor "334".
      * @throws IOException  If an I/O error occurs while either sending the command.
      */
     protected void execAUTH() throws SSLException, IOException {

--- a/src/main/java/org/apache/commons/net/ftp/parser/CompositeFileEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/CompositeFileEntryParser.java
@@ -22,8 +22,8 @@ import org.apache.commons.net.ftp.FTPFileEntryParser;
 import org.apache.commons.net.ftp.FTPFileEntryParserImpl;
 
 /**
- * This implementation allows to pack some FileEntryParsers together and handle the case where to returned dir style isn't clearly defined. The matching parser
- * will be cached. If the cached parser wont match due to the server changed the dir style, a new matching parser will be searched.
+ * This implementation allows to pack some FileEntryParsers together and handle the case where the returned dir style isn't clearly defined. The matching parser
+ * will be cached. If the cached parser won't match due to the server changed the dir style, a new matching parser will be searched.
  */
 public class CompositeFileEntryParser extends FTPFileEntryParserImpl {
     private final FTPFileEntryParser[] ftpFileEntryParsers;

--- a/src/main/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactory.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactory.java
@@ -51,7 +51,7 @@ public class DefaultFTPFileEntryParserFactory implements FTPFileEntryParserFacto
      *
      * @param config A {@link FTPClientConfig FTPClientConfig} used to configure the parser created
      *
-     * @return the @link FTPFileEntryParser FTPFileEntryParser} so created.
+     * @return the {@link FTPFileEntryParser} so created.
      * @throws ParserInitializationException Thrown on any exception in instantiation
      * @throws NullPointerException          if {@code config} is {@code null}
      * @since 1.4

--- a/src/main/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParser.java
@@ -119,7 +119,7 @@ public class EnterpriseUnixFTPEntryParser extends RegexFTPFileEntryParserImpl {
                     cal.set(Calendar.YEAR, Integer.parseInt(yr));
                     missingUnit = Calendar.HOUR_OF_DAY;
                 } else {
-                    // it must be hour/minute or we wouldn't have matched
+                    // it must be hour/minute, or we wouldn't have matched
                     missingUnit = Calendar.SECOND;
                     int year = cal.get(Calendar.YEAR);
 

--- a/src/main/java/org/apache/commons/net/ftp/parser/FTPFileEntryParserFactory.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/FTPFileEntryParserFactory.java
@@ -38,7 +38,7 @@ public interface FTPFileEntryParserFactory {
      *
      * @param config A {@link FTPClientConfig FTPClientConfig} used to configure the parser created
      *
-     * @return the @link FTPFileEntryParser FTPFileEntryParser} so created.
+     * @return the {@link FTPFileEntryParser} so created.
      * @throws ParserInitializationException Thrown on any exception in instantiation
      * @since 1.4
      */

--- a/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
@@ -90,7 +90,7 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
     }
 
     /*
-     * Sets the Calendar precision (used by FTPFile#toFormattedDate) by clearing the immediately preceeding unit (if any). Unfortunately the clear(int) method
+     * Sets the Calendar precision (used by FTPFile#toFormattedDate) by clearing the immediately preceding unit (if any). Unfortunately the clear(int) method
      * results in setting all other units.
      */
     private static void setPrecision(final int index, final Calendar working) {
@@ -361,7 +361,7 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
     }
 
     /**
-     * sets a TimeZone represented by the supplied ID string into all of the parsers used by this server.
+     * sets a TimeZone represented by the supplied ID string into all the parsers used by this server.
      *
      * @param serverTimeZoneId Time Id java.util.TimeZone id used by the ftp server. If null the client's local time zone is assumed.
      */

--- a/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
@@ -157,8 +157,8 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * --------------------------------------------------------------------- Very brief and incomplete description of the zOS/MVS-file system. (Note: "zOS" is
      * the operating system on the mainframe, and is the new name for MVS)
      *
-     * The file system on the mainframe does not have hierarchal structure as for example the unix file system. For a more comprehensive description, please
-     * refer to the IBM manuals
+     * The file system on the mainframe does not have hierarchical structure as for example the unix file system. For a more comprehensive description,
+     * please refer to the IBM manuals
      *
      * @LINK: http://publibfp.boulder.ibm.com/cgi-bin/bookmgr/BOOKS/dgt2d440/CONTENTS
      *
@@ -171,7 +171,7 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      *
      * Dataset organisation ====================
      *
-     * A dataset represents a piece of storage allocated on one or more disks. The structure of the storage is described with the field dataset organinsation
+     * A dataset represents a piece of storage allocated on one or more disks. The structure of the storage is described with the field dataset organisation
      * (DSORG). There are a number of dataset organisations, but only two are usable for FTP transfer.
      *
      * DSORG: PS: sequential, or flat file PO: partitioned dataset PO-E: extended partitioned dataset
@@ -184,16 +184,16 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      *
      * Dataset record format =====================
      *
-     * The physical layout of the dataset is described on the dataset itself. There are a number of record formats (RECFM), but just a few is relavant for the
+     * The physical layout of the dataset is described on the dataset itself. There are a number of record formats (RECFM), but just a few is relevant for the
      * FTP transfer.
      *
-     * Any one beginning with either F or V can safely used by FTP transfer. All others should only be used with great care. F means a fixed number of records
-     * per allocated storage, and V means a variable number of records.
+     * Any one beginning with either F or V can safely be used by FTP transfer. All others should only be used with great care. F means a fixed number of
+     * records per allocated storage, and V means a variable number of records.
      *
      *
      * Other notes ===========
      *
-     * The file system supports automatically backup and retrieval of datasets. If a file is backed up, the ftp LIST command will return: ARCIVE Not Direct
+     * The file system supports automatically backup and retrieval of datasets. If a file is backed up, the ftp LIST command will return: ARCHIVE Not Direct
      * Access Device KJ.IOP998.ERROR.PL.UNITTEST
      *
      *
@@ -240,16 +240,16 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
 
     /**
      * Parse entries representing a dataset list. Only datasets with DSORG PS or PO or PO-E and with RECFM F[B], V[B], U will be parsed.
-     *
+     * <p>
      * Format of ZOS/MVS file list: 1 2 3 4 5 6 7 8 9 10 Volume Unit Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname B10142 3390 2006/03/20 2 31 F 80 80 PS
-     * MDI.OKL.WORK ARCIVE Not Direct Access Device KJ.IOP998.ERROR.PL.UNITTEST B1N231 3390 2006/03/20 1 15 VB 256 27998 PO PLU B1N231 3390 2006/03/20 1 15 VB
+     * MDI.OKL.WORK ARCHIVE Not Direct Access Device KJ.IOP998.ERROR.PL.UNITTEST B1N231 3390 2006/03/20 1 15 VB 256 27998 PO PLU B1N231 3390 2006/03/20 1 15 VB
      * 256 27998 PO-E PLB
-     *
+     * <p>
      * ----------------------------------- Group within Regex [1] Volume [2] Unit [3] Referred [4] Ext: number of extents [5] Used [6] Recfm: Record format [7]
      * Lrecl: Logical record length [8] BlkSz: Block size [9] Dsorg: Dataset organisation. Many exists but only support: PS, PO, PO-E [10] Dsname: Dataset name
-     *
-     * Note: When volume is ARCIVE, it means the dataset is stored somewhere in a tape archive. These entries is currently not supported by this parser. A null
-     * value is returned.
+     * <p>
+     * Note: When volume is ARCHIVE, it means the dataset is stored somewhere in a tape archive. These entries are currently not supported by this parser.
+     * A null value is returned.
      *
      * @param entry zosDirectoryEntry
      * @return null: entry was not parsed.
@@ -279,8 +279,8 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     }
 
     /**
-     * Parses a line of an z/OS - MVS FTP server file listing and converts it into a usable format in the form of an <code> FTPFile </code> instance. If the
-     * file listing line doesn't describe a file, then <code> null </code> is returned. Otherwise a <code> FTPFile </code> instance representing the file is
+     * Parses a line of a z/OS - MVS FTP server file listing and converts it into a usable format in the form of an <code> FTPFile </code> instance. If the
+     * file listing line doesn't describe a file, then <code> null </code> is returned. Otherwise, a <code> FTPFile </code> instance representing the file is
      * returned.
      *
      * @param entry A line of text from the file listing
@@ -437,9 +437,12 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     }
 
     /**
-     * preParse is called as part of the interface. Per definition is is called before the parsing takes place. Three kind of lists is recognize: z/OS-MVS File
-     * lists z/OS-MVS Member lists unix file lists
-     *
+     * preParse is called as part of the interface. Per definition, it is called before the parsing takes place. Three kinds of lists are recognized:
+     * <ul>
+     *     <li>z/OS-MVS File lists,</li>
+     *     <li>z/OS-MVS Member lists,</li>
+     *     <li>unix file lists.</li>
+     * </ul>
      * @since 2.0
      */
     @Override

--- a/src/main/java/org/apache/commons/net/ftp/parser/MacOsPeterFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/MacOsPeterFTPEntryParser.java
@@ -40,7 +40,7 @@ public class MacOsPeterFTPEntryParser extends ConfigurableFTPFileEntryParserImpl
      * Permissions: r the file is readable w the file is writable x the file is executable - the indicated permission is not granted L mandatory locking occurs
      * during access (the set-group-ID bit is on and the group execution bit is off) s the set-user-ID or set-group-ID bit is on, and the corresponding user or
      * group execution bit is also on S undefined bit-state (the set-user-ID bit is on and the user execution bit is off) t the 1000 (octal) bit, or sticky bit,
-     * is on [see chmod(1)], and execution is on T the 1000 bit is turned on, and execution is off (undefined bit- state) e z/OS external link bit
+     * is on [see chmod(1)], and execution is on T the 1000 bit is turned on, and execution is off (undefined bit-state) e z/OS external link bit
      */
     private static final String REGEX = "([bcdelfmpSs-])" // type (1)
             + "(((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-])))\\+?\\s+" // permission
@@ -61,7 +61,7 @@ public class MacOsPeterFTPEntryParser extends ConfigurableFTPFileEntryParserImpl
     /**
      * The default constructor for a UnixFTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      */
     public MacOsPeterFTPEntryParser() {
@@ -72,7 +72,7 @@ public class MacOsPeterFTPEntryParser extends ConfigurableFTPFileEntryParserImpl
      * This constructor allows the creation of a UnixFTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      * @since 1.4
      */

--- a/src/main/java/org/apache/commons/net/ftp/parser/NTFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/NTFTPEntryParser.java
@@ -47,7 +47,7 @@ public class NTFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     /**
      * The sole constructor for an NTFTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      */
     public NTFTPEntryParser() {
@@ -58,7 +58,7 @@ public class NTFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * This constructor allows the creation of an NTFTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      * @since 1.4
      */

--- a/src/main/java/org/apache/commons/net/ftp/parser/NetwareFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/NetwareFTPEntryParser.java
@@ -23,7 +23,7 @@ import org.apache.commons.net.ftp.FTPClientConfig;
 import org.apache.commons.net.ftp.FTPFile;
 
 /**
- * Implementation of FTPFileEntryParser and FTPFileListParser for Netware Systems. Note that some of the proprietary extensions for Novell-specific operations
+ * Implementation of FTPFileEntryParser and FTPFileListParser for Netware Systems. Note that some proprietary extensions for Novell-specific operations
  * are not supported. See <a href="http://www.novell.com/documentation/nw65/index.html?page=/documentation/nw65/ftp_enu/data/fbhbgcfa.html">
  * http://www.novell.com/documentation/nw65/index.html?page=/documentation/nw65/ftp_enu/data/fbhbgcfa.html</a> for more details.
  *
@@ -54,7 +54,7 @@ public class NetwareFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     /**
      * The default constructor for a NetwareFTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      */
     public NetwareFTPEntryParser() {
@@ -65,7 +65,7 @@ public class NetwareFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * This constructor allows the creation of an NetwareFTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      * @since 1.4
      */

--- a/src/main/java/org/apache/commons/net/ftp/parser/OS2FTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/OS2FTPEntryParser.java
@@ -41,7 +41,7 @@ public class OS2FTPEntryParser extends ConfigurableFTPFileEntryParserImpl
     /**
      * The default constructor for a OS2FTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      */
     public OS2FTPEntryParser() {
@@ -52,7 +52,7 @@ public class OS2FTPEntryParser extends ConfigurableFTPFileEntryParserImpl
      * This constructor allows the creation of an OS2FTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      * @since 1.4
      */

--- a/src/main/java/org/apache/commons/net/ftp/parser/OS400FTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/OS400FTPEntryParser.java
@@ -243,7 +243,7 @@ public class OS400FTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     /**
      * The default constructor for a OS400FTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      */
     public OS400FTPEntryParser() {
@@ -254,7 +254,7 @@ public class OS400FTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * This constructor allows the creation of an OS400FTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If it is seen, this is a
      *                                  sign that <code>REGEX</code> is not a valid regular expression.
      * @since 1.4
      */
@@ -319,7 +319,7 @@ public class OS400FTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
                 }
             } else if (typeStr.equalsIgnoreCase("*FILE")) {
                 // File, defines the structure of the data (columns of a row)
-                // but the data is stored in one or more members. Typically a
+                // but the data is stored in one or more members. Typically, a
                 // source file contains multiple members whereas it is
                 // recommended (but not enforced) to use one member per data
                 // file.

--- a/src/main/java/org/apache/commons/net/ftp/parser/ParserInitializationException.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/ParserInitializationException.java
@@ -25,7 +25,7 @@ public class ParserInitializationException extends RuntimeException {
     private static final long serialVersionUID = 5563335279583210658L;
 
     /**
-     * Constucts a ParserInitializationException with just a message
+     * Constructs a ParserInitializationException with just a message
      *
      * @param message Exception message
      */

--- a/src/main/java/org/apache/commons/net/ftp/parser/RegexFTPFileEntryParserImpl.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/RegexFTPFileEntryParserImpl.java
@@ -51,7 +51,7 @@ public abstract class RegexFTPFileEntryParserImpl extends FTPFileEntryParserImpl
      *
      * @param regex The regular expression with which this object is initialized.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen in normal conditions. It it is seen, this is a sign
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen in normal conditions. If it is seen, this is a sign
      *                                  that a subclass has been created with a bad regular expression. Since the parser must be created before use, this means
      *                                  that any bad parser subclasses created from this will bomb very quickly, leading to easy detection.
      */
@@ -66,7 +66,7 @@ public abstract class RegexFTPFileEntryParserImpl extends FTPFileEntryParserImpl
      * @param regex The regular expression with which this object is initialized.
      * @param flags the flags to apply, see {@link Pattern#compile(String, int)}. Use 0 for none.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen in normal conditions. It it is seen, this is a sign
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen in normal conditions. If it is seen, this is a sign
      *                                  that a subclass has been created with a bad regular expression. Since the parser must be created before use, this means
      *                                  that any bad parser subclasses created from this will bomb very quickly, leading to easy detection.
      * @since 3.4

--- a/src/main/java/org/apache/commons/net/ftp/parser/UnixFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/UnixFTPEntryParser.java
@@ -51,7 +51,7 @@ public class UnixFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     /**
      * Some Linux distributions are now shipping an FTP server which formats file listing dates in an all-numeric format: <code>"yyyy-MM-dd HH:mm</code>. This
      * is a very welcome development, and hopefully it will soon become the standard. However, since it is so new, for now, and possibly forever, we merely
-     * accomodate it, but do not make it the default.
+     * accommodate it, but do not make it the default.
      * <p>
      * For now end users may specify this format only via <code>UnixFTPEntryParser(FTPClientConfig)</code>. Steve Cohen - 2005-04-17
      */
@@ -63,7 +63,7 @@ public class UnixFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * Permissions: r the file is readable w the file is writable x the file is executable - the indicated permission is not granted L mandatory locking occurs
      * during access (the set-group-ID bit is on and the group execution bit is off) s the set-user-ID or set-group-ID bit is on, and the corresponding user or
      * group execution bit is also on S undefined bit-state (the set-user-ID bit is on and the user execution bit is off) t the 1000 (octal) bit, or sticky bit,
-     * is on [see chmod(1)], and execution is on T the 1000 bit is turned on, and execution is off (undefined bit- state) e z/OS external link bit Final letter
+     * is on [see chmod(1)], and execution is on T the 1000 bit is turned on, and execution is off (undefined bit-state) e z/OS external link bit. Final letter
      * may be appended: + file has extended security attributes (e.g. ACL) Note: local listings on MacOSX also use '@'; this is not allowed for here as does not
      * appear to be shown by FTP servers {@code @} file has extended attributes
      */
@@ -110,8 +110,8 @@ public class UnixFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     /**
      * The default constructor for a UnixFTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
-     *                                  sign that <code>REGEX</code> is not a valid regular expression.
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions.
+     *                                  If this exception is seen, this is a sign that {@code REGEX} is not a valid regular expression.
      */
     public UnixFTPEntryParser() {
         this(null);
@@ -121,8 +121,8 @@ public class UnixFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * This constructor allows the creation of a UnixFTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
-     *                                  sign that <code>REGEX</code> is not a valid regular expression.
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions.
+     *                                  If this exception is seen, this is a sign that {@code REGEX} is not a valid regular expression.
      * @since 1.4
      */
     public UnixFTPEntryParser(final FTPClientConfig config) {
@@ -134,8 +134,8 @@ public class UnixFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      *
      * @param config            The {@link FTPClientConfig configuration} object used to configure this parser.
      * @param trimLeadingSpaces if {@code true}, trim leading spaces from file names
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
-     *                                  sign that <code>REGEX</code> is not a valid regular expression.
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions.
+     *                                  If this exception is seen, this is a sign that {@code REGEX} is not a valid regular expression.
      * @since 3.4
      */
     public UnixFTPEntryParser(final FTPClientConfig config, final boolean trimLeadingSpaces) {

--- a/src/main/java/org/apache/commons/net/ftp/parser/VMSFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/VMSFTPEntryParser.java
@@ -57,8 +57,8 @@ public class VMSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
     /**
      * Constructor for a VMSFTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
-     *                                  sign that <code>REGEX</code> is not a valid regular expression.
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If the exception is seen,
+     *                                  this is a sign that <code>REGEX</code> is not a valid regular expression.
      */
     public VMSFTPEntryParser() {
         this(null);
@@ -68,8 +68,8 @@ public class VMSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * This constructor allows the creation of a VMSFTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
-     *                                  sign that <code>REGEX</code> is not a valid regular expression.
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If the exception is seen,
+     *                                  this is a sign that <code>REGEX</code> is not a valid regular expression.
      * @since 1.4
      */
     public VMSFTPEntryParser(final FTPClientConfig config) {

--- a/src/main/java/org/apache/commons/net/ftp/parser/VMSVersioningFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/VMSVersioningFTPEntryParser.java
@@ -50,8 +50,8 @@ public class VMSVersioningFTPEntryParser extends VMSFTPEntryParser {
     /**
      * Constructor for a VMSFTPEntryParser object.
      *
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
-     *                                  sign that <code>REGEX</code> is not a valid regular expression.
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If the exception is seen,
+     *                                  this is a sign that <code>REGEX</code> is not a valid regular expression.
      */
     public VMSVersioningFTPEntryParser() {
         this(null);
@@ -61,8 +61,8 @@ public class VMSVersioningFTPEntryParser extends VMSFTPEntryParser {
      * This constructor allows the creation of a VMSVersioningFTPEntryParser object with something other than the default configuration.
      *
      * @param config The {@link FTPClientConfig configuration} object used to configure this parser.
-     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. It it is seen, this is a
-     *                                  sign that <code>REGEX</code> is not a valid regular expression.
+     * @throws IllegalArgumentException Thrown if the regular expression is unparseable. Should not be seen under normal conditions. If the exception is seen,
+     *                                  this is a sign that <code>REGEX</code> is not a valid regular expression.
      * @since 1.4
      */
     public VMSVersioningFTPEntryParser(final FTPClientConfig config) {

--- a/src/main/java/org/apache/commons/net/imap/IMAP.java
+++ b/src/main/java/org/apache/commons/net/imap/IMAP.java
@@ -193,7 +193,7 @@ public class IMAP extends SocketClient {
     }
 
     /**
-     * Overrides {@link SocketClient#fireReplyReceived(int, String)} so as to avoid creating the reply string if there are no listeners to invoke.
+     * Overrides {@link SocketClient#fireReplyReceived(int, String)} to avoid creating the reply string if there are no listeners to invoke.
      *
      * @param replyCode passed to the listeners
      * @param ignored   the string is only created if there are listeners defined.
@@ -374,7 +374,7 @@ public class IMAP extends SocketClient {
      * @param commandID The ID (tag) of the command.
      * @param command   The IMAP command to send.
      * @param args      The command arguments.
-     * @return The server reply code (either IMAPReply.OK, IMAPReply.NO or IMAPReply.BAD).
+     * @return The server reply code (either {@link IMAPReply#OK}, {@link IMAPReply#NO} or {@link IMAPReply#BAD}).
      */
     private int sendCommandWithID(final String commandID, final String command, final String args) throws IOException {
         final StringBuilder __commandBuffer = new StringBuilder();

--- a/src/main/java/org/apache/commons/net/imap/IMAPClient.java
+++ b/src/main/java/org/apache/commons/net/imap/IMAPClient.java
@@ -384,7 +384,7 @@ public class IMAPClient extends IMAP {
 
     /**
      * Login to the IMAP server with the given username and password. You must first connect to the server with
-     * {@link org.apache.commons.net.SocketClient#connect connect } before attempting to login. A login attempt is only valid if the client is in the
+     * {@link org.apache.commons.net.SocketClient#connect connect } before attempting to log in. A login attempt is only valid if the client is in the
      * NOT_AUTH_STATE. After logging in, the client enters the AUTH_STATE.
      *
      * @param username The account name being logged in to.
@@ -432,7 +432,7 @@ public class IMAPClient extends IMAP {
     }
 
     /**
-     * Send a NOOP command to the server. This is useful for keeping a connection alive since most IMAP servers will timeout after 10 minutes of inactivity.
+     * Send a NOOP command to the server. This is useful for keeping a connection alive since most IMAP servers will time out after 10 minutes of inactivity.
      *
      * @return {@code true} if the command was successful,{@code false} if not.
      * @throws IOException If a network I/O error occurs.

--- a/src/main/java/org/apache/commons/net/imap/IMAPReply.java
+++ b/src/main/java/org/apache/commons/net/imap/IMAPReply.java
@@ -74,7 +74,7 @@ public final class IMAPReply {
     private static final Pattern LITERAL_PATTERN = Pattern.compile("\\{(\\d+)\\}$"); // {dd}
 
     /**
-     * Intepret the String reply code - OK, NO, BAD - in a tagged response as a integer.
+     * Interpret the String reply code - OK, NO, BAD - in a tagged response as an integer.
      *
      * @param line the tagged line to be checked
      * @return {@link #OK} or {@link #NO} or {@link #BAD} or {@link #CONT}
@@ -106,7 +106,7 @@ public final class IMAPReply {
     }
 
     /**
-     * Intepret the String reply code - OK, NO, BAD - in an untagged response as a integer.
+     * Interpret the String reply code - OK, NO, BAD - in an untagged response as an integer.
      *
      * @param line the untagged line to be checked
      * @return {@link #OK} or {@link #NO} or {@link #BAD} or {@link #CONT}

--- a/src/main/java/org/apache/commons/net/imap/IMAPSClient.java
+++ b/src/main/java/org/apache/commons/net/imap/IMAPSClient.java
@@ -89,7 +89,7 @@ public class IMAPSClient extends IMAPClient {
     /** The {@link HostnameVerifier} to use post-TLS, default null (i.e. no verification). */
     private HostnameVerifier hostnameVerifier;
 
-    /** Use Java 1.7+ HTTPS Endpoint Identification Algorithim. */
+    /** Use Java 1.7+ HTTPS Endpoint Identification Algorithm. */
     private boolean tlsEndpointChecking;
 
     /**
@@ -162,7 +162,7 @@ public class IMAPSClient extends IMAPClient {
 
     /**
      * Because there are so many connect() methods, the _connectAction_() method is provided as a means of performing some action immediately after establishing
-     * a connection, rather than reimplementing all of the connect() methods.
+     * a connection, rather than reimplementing all the connect() methods.
      *
      * @throws IOException If it is thrown by _connectAction_().
      * @see org.apache.commons.net.SocketClient#_connectAction_()

--- a/src/main/java/org/apache/commons/net/io/DotTerminatedMessageReader.java
+++ b/src/main/java/org/apache/commons/net/io/DotTerminatedMessageReader.java
@@ -25,13 +25,13 @@ import org.apache.commons.net.util.NetConstants;
 
 /**
  * DotTerminatedMessageReader is a class used to read messages from a server that are terminated by a single dot followed by a &lt;CR&gt;&lt;LF&gt; sequence and
- * with double dots appearing at the begining of lines which do not signal end of message yet start with a dot. Various Internet protocols such as NNTP and POP3
- * produce messages of this type.
+ * with double dots appearing at the beginning of lines which do not signal end of message yet start with a dot. Various Internet protocols such as
+ * NNTP and POP3 produce messages of this type.
  * <p>
  * This class handles stripping of the duplicate period at the beginning of lines starting with a period, and ensures you cannot read past the end of the
  * message.
  * <p>
- * Note: versions since 3.0 extend BufferedReader rather than Reader, and no longer change the CRLF into the local EOL. Also only DOT CR LF acts as EOF.
+ * Note: versions since 3.0 extend BufferedReader rather than Reader, and no longer change the CRLF into the local EOL. Also, only DOT CR LF acts as EOF.
  */
 public final class DotTerminatedMessageReader extends BufferedReader {
     private static final char LF = '\n';

--- a/src/main/java/org/apache/commons/net/io/DotTerminatedMessageWriter.java
+++ b/src/main/java/org/apache/commons/net/io/DotTerminatedMessageWriter.java
@@ -22,15 +22,12 @@ import java.io.Writer;
 
 /**
  * DotTerminatedMessageWriter is a class used to write messages to a server that are terminated by a single dot followed by a &lt;CR&gt;&lt;LF&gt; sequence and
- * with double dots appearing at the begining of lines which do not signal end of message yet start with a dot. Various Internet protocols such as NNTP and POP3
- * produce messages of this type.
+ * with double dots appearing at the beginning of lines which do not signal end of message yet start with a dot. Various Internet protocols such as
+ * NNTP and POP3 produce messages of this type.
  * <p>
  * This class handles the doubling of line-starting periods, converts single linefeeds to NETASCII newlines, and on closing will send the final message
  * terminator dot and NETASCII newline sequence.
- *
- *
  */
-
 public final class DotTerminatedMessageWriter extends Writer {
     private static final int NOTHING_SPECIAL_STATE = 0;
     private static final int LAST_WAS_CR_STATE = 1;

--- a/src/main/java/org/apache/commons/net/io/Util.java
+++ b/src/main/java/org/apache/commons/net/io/Util.java
@@ -89,7 +89,7 @@ public final class Util {
 
     /**
      * Copies the contents of a Reader to a Writer using a copy buffer of a given size. The contents of the Reader are read until its end is reached, but
-     * neither the source nor the destination are closed. You must do this yourself outside of the method call. The number of characters read/written is
+     * neither the source nor the destination are closed. You must do this yourself outside the method call. The number of characters read/written is
      * returned.
      *
      * @param source     The source Reader.
@@ -110,7 +110,7 @@ public final class Util {
      * operation by calling its bytesTransferred(long, int) method after each write to the destination. If you wish to notify more than one listener you should
      * use a CopyStreamAdapter as the listener and register the additional listeners with the CopyStreamAdapter.
      * <p>
-     * The contents of the Reader are read until its end is reached, but neither the source nor the destination are closed. You must do this yourself outside of
+     * The contents of the Reader are read until its end is reached, but neither the source nor the destination are closed. You must do this yourself outside
      * the method call. The number of characters read/written is returned.
      *
      * @param source     The source Reader.
@@ -133,7 +133,7 @@ public final class Util {
 
         try {
             while ((numChars = source.read(buffer)) != NetConstants.EOS) {
-                // Technically, some read(char[]) methods may return 0 and we cannot
+                // Technically, some read(char[]) methods may return 0, and we cannot
                 // accept that as an indication of EOF.
                 if (numChars == 0) {
                     final int singleChar = source.read();
@@ -177,7 +177,7 @@ public final class Util {
 
     /**
      * Copies the contents of an InputStream to an OutputStream using a copy buffer of a given size. The contents of the InputStream are read until the end of
-     * the stream is reached, but neither the source nor the destination are closed. You must do this yourself outside of the method call. The number of bytes
+     * the stream is reached, but neither the source nor the destination are closed. You must do this yourself outside the method call. The number of bytes
      * read/written is returned.
      *
      * @param source     The source InputStream.
@@ -199,7 +199,7 @@ public final class Util {
      * you should use a CopyStreamAdapter as the listener and register the additional listeners with the CopyStreamAdapter.
      * <p>
      * The contents of the InputStream are read until the end of the stream is reached, but neither the source nor the destination are closed. You must do this
-     * yourself outside of the method call. The number of bytes read/written is returned.
+     * yourself outside the method call. The number of bytes read/written is returned.
      *
      * @param source     The source InputStream.
      * @param dest       The destination OutputStream.
@@ -224,7 +224,7 @@ public final class Util {
      * you should use a CopyStreamAdapter as the listener and register the additional listeners with the CopyStreamAdapter.
      * <p>
      * The contents of the InputStream are read until the end of the stream is reached, but neither the source nor the destination are closed. You must do this
-     * yourself outside of the method call. The number of bytes read/written is returned.
+     * yourself outside the method call. The number of bytes read/written is returned.
      *
      * @param source     The source InputStream.
      * @param dest       The destination OutputStream.
@@ -248,7 +248,7 @@ public final class Util {
 
         try {
             while ((numBytes = source.read(buffer)) != NetConstants.EOS) {
-                // Technically, some read(byte[]) methods may return 0 and we cannot
+                // Technically, some read(byte[]) methods may return 0, and we cannot
                 // accept that as an indication of EOF.
 
                 if (numBytes == 0) {

--- a/src/main/java/org/apache/commons/net/nntp/NNTP.java
+++ b/src/main/java/org/apache/commons/net/nntp/NNTP.java
@@ -60,7 +60,7 @@ public class NNTP extends SocketClient {
     /** The default NNTP port. Its value is 119 according to RFC 977. */
     public static final int DEFAULT_PORT = 119;
 
-    // We have to ensure that the protocol communication is in ASCII
+    // We have to ensure that the protocol communication is in ASCII,
     // but we use ISO-8859-1 just in case 8-bit characters cross
     // the wire.
     private static final Charset DEFAULT_ENCODING = StandardCharsets.ISO_8859_1;

--- a/src/main/java/org/apache/commons/net/nntp/NNTPClient.java
+++ b/src/main/java/org/apache/commons/net/nntp/NNTPClient.java
@@ -268,9 +268,9 @@ public class NNTPClient extends NNTP {
     }
 
     /**
-     * List all new articles added to the NNTP server since a particular date subject to the conditions of the specified query. If no new new news is found, no
-     * entries will be returned. This uses the "NEWNEWS" command. You must add at least one newsgroup to the query, else the command will fail. Each String
-     * which is returned is a unique message identifier including the enclosing &lt; and &gt;.
+     * List all new articles added to the NNTP server since a particular date subject to the conditions of the specified query. If no new news is found,
+     * no entries will be returned. This uses the "NEWNEWS" command. You must add at least one newsgroup to the query, else the command will fail.
+     * Each String which is returned is a unique message identifier including the enclosing &lt; and &gt;.
      * <p>
      *
      * @param query The query restricting how to search for new news. You must add at least one newsgroup to the query.
@@ -416,7 +416,7 @@ public class NNTPClient extends NNTP {
     }
 
     /**
-     * List all new articles added to the NNTP server since a particular date subject to the conditions of the specified query. If no new new news is found, a
+     * List all new articles added to the NNTP server since a particular date subject to the conditions of the specified query. If no new news is found, a
      * zero length array will be returned. If the command fails, null will be returned. You must add at least one newsgroup to the query, else the command will
      * fail. Each String in the returned array is a unique message identifier including the enclosing &lt; and &gt;. This uses the "NEWNEWS" command.
      * <p>
@@ -583,12 +583,12 @@ public class NNTPClient extends NNTP {
      * due to malformed headers.
      * <p>
      * You must not issue any commands to the NNTP server (i.e., call any (other methods) until you finish writing to the returned Writer instance and close it.
-     * The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned Writer actually writes directly to
+     * The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned Writer actually writes directly to
      * the NNTP connection. After you close the writer, you can execute new commands. If you do not follow these requirements your program will not work
      * properly.
      * <p>
      * Different NNTP servers will require different header formats, but you can use the provided {@link org.apache.commons.net.nntp.SimpleNNTPHeader} class to
-     * construct the bare minimum acceptable header for most news readers. To construct more complicated headers you should refer to RFC 822. When the Java Mail
+     * construct the bare minimum acceptable header for most newsreaders. To construct more complicated headers you should refer to RFC 822. When the Java Mail
      * API is finalized, you will be able to use it to compose fully compliant Internet text messages. The DotTerminatedMessageWriter takes care of doubling
      * line-leading dots and ending the message with a single dot upon closing, so all you have to worry about is writing the header and the message.
      * <p>
@@ -674,7 +674,7 @@ public class NNTPClient extends NNTP {
     }
 
     /**
-     * @param articleNumber The number of the the article to retrieve
+     * @param articleNumber The number of the article to retrieve
      * @return A DotTerminatedMessageReader instance from which the article can be read. null if the article does not exist.
      * @throws IOException on error
      * @deprecated 3.0 use {@link #retrieveArticle(long)} instead
@@ -685,7 +685,7 @@ public class NNTPClient extends NNTP {
     }
 
     /**
-     * @param articleNumber The number of the the article to retrieve.
+     * @param articleNumber The number of the article to retrieve.
      * @param pointer       A parameter through which to return the article's number and unique id
      * @return A DotTerminatedMessageReader instance from which the article can be read. null if the article does not exist.
      * @throws IOException on error
@@ -718,12 +718,12 @@ public class NNTPClient extends NNTP {
      * A DotTerminatedMessageReader is returned from which the article can be read. If the article does not exist, null is returned.
      * <p>
      * You must not issue any commands to the NNTP server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
+     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader actually
      * reads directly from the NNTP connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
      * follow these requirements, your program will not work properly.
      * <p>
      *
-     * @param articleNumber The number of the the article to retrieve.
+     * @param articleNumber The number of the article to retrieve.
      * @param pointer       A parameter through which to return the article's number and unique id. The articleId field cannot always be trusted because of
      *                      server deviations from RFC 977 reply formats. You may set this parameter to null if you do not desire to retrieve the returned
      *                      article information.
@@ -756,7 +756,7 @@ public class NNTPClient extends NNTP {
      * A DotTerminatedMessageReader is returned from which the article can be read. If the article does not exist, null is returned.
      * <p>
      * You must not issue any commands to the NNTP server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
+     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader actually
      * reads directly from the NNTP connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
      * follow these requirements, your program will not work properly.
      * <p>
@@ -846,12 +846,12 @@ public class NNTPClient extends NNTP {
      * A DotTerminatedMessageReader is returned from which the article can be read. If the article does not exist, null is returned.
      * <p>
      * You must not issue any commands to the NNTP server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
+     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader actually
      * reads directly from the NNTP connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
      * follow these requirements, your program will not work properly.
      * <p>
      *
-     * @param articleNumber The number of the the article whose body is being retrieved.
+     * @param articleNumber The number of the article whose body is being retrieved.
      * @param pointer       A parameter through which to return the article's number and unique id. The articleId field cannot always be trusted because of
      *                      server deviations from RFC 977 reply formats. You may set this parameter to null if you do not desire to retrieve the returned
      *                      article information.
@@ -884,7 +884,7 @@ public class NNTPClient extends NNTP {
      * A DotTerminatedMessageReader is returned from which the article can be read. If the article does not exist, null is returned.
      * <p>
      * You must not issue any commands to the NNTP server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
+     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader actually
      * reads directly from the NNTP connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
      * follow these requirements, your program will not work properly.
      * <p>
@@ -975,12 +975,12 @@ public class NNTPClient extends NNTP {
      * A DotTerminatedMessageReader is returned from which the article can be read. If the article does not exist, null is returned.
      * <p>
      * You must not issue any commands to the NNTP server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
+     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader actually
      * reads directly from the NNTP connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
      * follow these requirements, your program will not work properly.
      * <p>
      *
-     * @param articleNumber The number of the the article whose header is being retrieved.
+     * @param articleNumber The number of the article whose header is being retrieved.
      * @param pointer       A parameter through which to return the article's number and unique id. The articleId field cannot always be trusted because of
      *                      server deviations from RFC 977 reply formats. You may set this parameter to null if you do not desire to retrieve the returned
      *                      article information.
@@ -1013,7 +1013,7 @@ public class NNTPClient extends NNTP {
      * A DotTerminatedMessageReader is returned from which the article can be read. If the article does not exist, null is returned.
      * <p>
      * You must not issue any commands to the NNTP server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
+     * instance. The NNTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader actually
      * reads directly from the NNTP connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
      * follow these requirements, your program will not work properly.
      * <p>
@@ -1283,7 +1283,7 @@ public class NNTPClient extends NNTP {
     /**
      * Same as <code> selectArticle(articleId, (ArticleInfo) null) </code>
      *
-     * @param articleId the article Id
+     * @param articleId the article's Id
      * @return true if successful
      * @throws IOException on error
      */
@@ -1442,7 +1442,7 @@ public class NNTPClient extends NNTP {
     // Helper methods
 
     /**
-     * Select the article preceeding the currently selected article in the currently selected newsgroup and return its number and unique id through the pointer
+     * Select the article preceding the currently selected article in the currently selected newsgroup and return its number and unique id through the pointer
      * parameter. Because of deviating server implementations, the articleId information cannot be trusted. To obtain the article identifier, issue a
      * <code> selectArticle(pointer.articleNumber, pointer) </code> immediately afterward.
      * <p>

--- a/src/main/java/org/apache/commons/net/nntp/NNTPReply.java
+++ b/src/main/java/org/apache/commons/net/nntp/NNTPReply.java
@@ -68,7 +68,7 @@ public final class NNTPReply {
 
     /**
      * Determine if a reply code is an informational response. All codes beginning with a 1 are positive informational responses. Informational responses are
-     * used to provide human readable information such as help text.
+     * used to provide human-readable information such as help text.
      * <p>
      *
      * @param reply The reply code to test.
@@ -117,7 +117,7 @@ public final class NNTPReply {
 
     /**
      * Determine if a reply code is a positive intermediate response. All codes beginning with a 3 are positive intermediate responses. The NNTP server will
-     * send a positive intermediate response on the successful completion of one part of a multi-part command or sequence of commands. For example, after a
+     * send a positive intermediate response on the successful completion of one part of a multipart command or sequence of commands. For example, after a
      * successful POST command, a positive intermediate response will be sent to indicate that the server is ready to receive the article to be posted.
      * <p>
      *

--- a/src/main/java/org/apache/commons/net/nntp/NewGroupsOrNewsQuery.java
+++ b/src/main/java/org/apache/commons/net/nntp/NewGroupsOrNewsQuery.java
@@ -246,7 +246,7 @@ public final class NewGroupsOrNewsQuery {
      * </pre>
      * <p>
      *
-     * @param newsgroup The newsgroup to add to the list of groups to be checked for new news, but which should be omitted from the search for new news..
+     * @param newsgroup The newsgroup to add to the list of groups to be checked for new news, but which should be omitted from the search for new news.
      */
     public void omitNewsgroup(final String newsgroup) {
         addNewsgroup("!" + newsgroup);

--- a/src/main/java/org/apache/commons/net/nntp/NewsgroupInfo.java
+++ b/src/main/java/org/apache/commons/net/nntp/NewsgroupInfo.java
@@ -28,7 +28,7 @@ package org.apache.commons.net.nntp;
 public final class NewsgroupInfo {
     /**
      * A constant indicating that the posting permission of a newsgroup is unknown. For example, the NNTP GROUP command does not return posting information, so
-     * NewsgroupInfo instances obtained from that command willhave an UNKNOWN_POSTING_PERMISSION.
+     * NewsgroupInfo instances obtained from that command will have an UNKNOWN_POSTING_PERMISSION.
      */
     public static final int UNKNOWN_POSTING_PERMISSION = 0;
 

--- a/src/main/java/org/apache/commons/net/nntp/SimpleNNTPHeader.java
+++ b/src/main/java/org/apache/commons/net/nntp/SimpleNNTPHeader.java
@@ -18,7 +18,7 @@
 package org.apache.commons.net.nntp;
 
 /**
- * This class is used to construct the bare minimum acceptable header for most news readers. To construct more complicated headers you should refer to RFC 822.
+ * This class is used to construct the bare minimum acceptable header for most newsreaders. To construct more complicated headers you should refer to RFC 822.
  * When the Java Mail API is finalized, you will be able to use it to compose fully compliant Internet text messages.
  * <p>
  * The main purpose of the class is to faciliatate the article posting process, by relieving the programmer from having to explicitly format an article header.
@@ -63,8 +63,9 @@ public class SimpleNNTPHeader {
     }
 
     /**
-     * Adds an arbitrary header field with the given value to the article header. These headers will be written after the From, Newsgroups, and Subject fields
-     * when the SimpleNNTPHeader is convertered to a string. An example use would be:
+     * Adds an arbitrary header field with the given value to the article header.
+     * These headers will be written after the {@code From}, Newsgroups, and Subject fields
+     * when the SimpleNNTPHeader is converted to a string. An example use would be:
      *
      * <pre>
      * header.addHeaderField("Organization", "Foobar, Inc.");

--- a/src/main/java/org/apache/commons/net/nntp/Threader.java
+++ b/src/main/java/org/apache/commons/net/nntp/Threader.java
@@ -17,6 +17,11 @@
 
 package org.apache.commons.net.nntp;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * This is an implementation of a message threading algorithm, as originally devised by Zamie Zawinski.
  * See <a href="http://www.jwz.org/doc/threading.html">http://www.jwz.org/doc/threading.html</a> for details.
@@ -24,12 +29,6 @@ package org.apache.commons.net.nntp;
  * <a href="http://lxr.mozilla.org/mozilla/source/grendel/sources/grendel/view/Threader.java">
  * http://lxr.mozilla.org/mozilla/source/grendel/sources/grendel/view/Threader.java</a>
  */
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 public class Threader {
 
     /**
@@ -63,7 +62,7 @@ public class Threader {
             idTable.put(id, container);
         }
 
-        // Iterate through all of the references and create ThreadContainers for any references that
+        // Iterate through all the references and create ThreadContainers for any references that
         // don't have them.
         ThreadContainer parentRef = null;
         {
@@ -71,14 +70,14 @@ public class Threader {
             for (final String refString : references) {
                 ThreadContainer ref = idTable.get(refString);
 
-                // if this id doesnt have a container, create one
+                // if this id doesn't have a container, create one
                 if (ref == null) {
                     ref = new ThreadContainer();
                     idTable.put(refString, ref);
                 }
 
                 // Link references together in the order they appear in the References: header,
-                // IF they dont have a have a parent already &&
+                // IF they don't have a parent already &&
                 // IF it will not cause a circular reference
                 if ((parentRef != null) && (ref.parent == null) && (parentRef != ref) && !(ref.findChild(parentRef))) {
                     // Link ref into the parent's child list
@@ -96,7 +95,7 @@ public class Threader {
             parentRef = null;
         }
 
-        // if it has a parent already, its because we saw this message in a References: field, and presumed
+        // if it has a parent already, it's because we saw this message in a References: field, and presumed
         // a parent based on the other entries in that field. Now that we have the actual message, we can
         // throw away the old parent and use this new one
         if (container.parent != null) {
@@ -173,7 +172,7 @@ public class Threader {
             Threadable threadable = c.threadable;
 
             // No threadable? If so, it is a dummy node in the root set.
-            // Only root set members may be dummies, and they alway have at least 2 kids
+            // Only root set members may be dummies, and they always have at least 2 kids
             // Take the first kid as representative of the subject
             if (threadable == null) {
                 threadable = c.child.threadable;
@@ -219,7 +218,7 @@ public class Threader {
 
             final String subj = threadable.simplifiedSubject();
 
-            // Dont thread together all subjectless messages
+            // Don't thread together all subjectless messages
             if (subj == null || subj.isEmpty()) {
                 continue;
             }
@@ -336,7 +335,7 @@ public class Threader {
                 tail.parent = container.parent;
                 tail.next = container.next;
 
-                // next currently points to the item after the inserted items in the chain - reset that so we process the newly
+                // next currently points to the item after the inserted items in the chain - reset that, so we process the newly
                 // promoted items next time round
                 next = kids;
 

--- a/src/main/java/org/apache/commons/net/ntp/NTPUDPClient.java
+++ b/src/main/java/org/apache/commons/net/ntp/NTPUDPClient.java
@@ -39,7 +39,7 @@ public final class NTPUDPClient extends DatagramSocketClient {
     private int version = NtpV3Packet.VERSION_3;
 
     /**
-     * Retrieves the time information from the specified server on the default NTP port and returns it. The time is the number of miliiseconds since 00:00
+     * Retrieves the time information from the specified server on the default NTP port and returns it. The time is the number of milliseconds since 00:00
      * (midnight) 1 January 1900 UTC, as specified by RFC 1305. This method reads the raw NTP packet and constructs a <i>TimeInfo</i> object that allows access
      * to all the fields of the NTP message header.
      * <p>
@@ -53,7 +53,7 @@ public final class NTPUDPClient extends DatagramSocketClient {
     }
 
     /**
-     * Retrieves the time information from the specified server and port and returns it. The time is the number of miliiseconds since 00:00 (midnight) 1 January
+     * Retrieves the time information from the specified server and port and returns it. The time is the number of milliseconds since 00:00 (midnight) 1 January
      * 1900 UTC, as specified by RFC 1305. This method reads the raw NTP packet and constructs a <i>TimeInfo</i> object that allows access to all the fields of
      * the NTP message header.
      * <p>

--- a/src/main/java/org/apache/commons/net/ntp/NtpV3Impl.java
+++ b/src/main/java/org/apache/commons/net/ntp/NtpV3Impl.java
@@ -51,7 +51,7 @@ public class NtpV3Impl implements NtpV3Packet {
 //    private static final int MESSAGE_DIGEST = 54; /* len 16 bytes */
 
     /**
-     * Convert byte to unsigned integer. Java only has signed types so we have to do more work to get unsigned ops.
+     * Convert byte to unsigned integer. Java only has signed types, so we have to do more work to get unsigned ops.
      *
      * @param b input byte
      * @return unsigned int value of byte
@@ -62,7 +62,7 @@ public class NtpV3Impl implements NtpV3Packet {
     }
 
     /**
-     * Convert byte to unsigned long. Java only has signed types so we have to do more work to get unsigned ops
+     * Convert byte to unsigned long. Java only has signed types, so we have to do more work to get unsigned ops
      *
      * @param b input byte
      * @return unsigned long value of byte
@@ -166,9 +166,9 @@ public class NtpV3Impl implements NtpV3Packet {
     }
 
     /**
-     * Returns the originate time as defined in RFC-1305.
+     * Returns the {@code originate} time as defined in RFC-1305.
      *
-     * @return the originate time. Never returns null.
+     * @return the {@code originate} time. Never returns null.
      */
     @Override
     public TimeStamp getOriginateTimeStamp() {
@@ -177,7 +177,7 @@ public class NtpV3Impl implements NtpV3Packet {
 
     /**
      * Returns poll interval as defined in RFC-1305, which is an eight-bit signed integer indicating the maximum interval between successive messages, in
-     * seconds to the nearest power of two (e.g. value of six indicates an interval of 64 seconds. The values that can appear in this field range from
+     * seconds to the nearest power of two (e.g. value of six indicates an interval of 64 seconds). The values that can appear in this field range from
      * NTP_MINPOLL to NTP_MAXPOLL inclusive.
      *
      * @return poll interval as defined in RFC-1305.
@@ -188,7 +188,7 @@ public class NtpV3Impl implements NtpV3Packet {
     }
 
     /**
-     * Returns precision as defined in RFC-1305 encoded as an 8-bit signed integer (seconds to nearest power of two). Values normally range from -6 to -20.
+     * Returns precision as defined in RFC-1305 encoded as an 8-bit signed integer (seconds to the nearest power of two). Values normally range from -6 to -20.
      *
      * @return precision as defined in RFC-1305.
      */
@@ -198,9 +198,9 @@ public class NtpV3Impl implements NtpV3Packet {
     }
 
     /**
-     * Returns receive timestamp as defined in RFC-1305.
+     * Returns {@code receive} timestamp as defined in RFC-1305.
      *
-     * @return the receive time. Never returns null.
+     * @return the {@code receive} time. Never returns null.
      */
     @Override
     public TimeStamp getReceiveTimeStamp() {
@@ -332,9 +332,9 @@ public class NtpV3Impl implements NtpV3Packet {
     }
 
     /**
-     * Returns the transmit timestamp as defined in RFC-1305.
+     * Returns the {@code transmit} timestamp as defined in RFC-1305.
      *
-     * @return the transmit timestamp as defined in RFC-1305. Never returns a null object.
+     * @return the {@code transmit} timestamp as defined in RFC-1305. Never returns a null object.
      */
     @Override
     public TimeStamp getTransmitTimeStamp() {

--- a/src/main/java/org/apache/commons/net/ntp/NtpV3Packet.java
+++ b/src/main/java/org/apache/commons/net/ntp/NtpV3Packet.java
@@ -83,7 +83,7 @@ public interface NtpV3Packet {
     String getModeName();
 
     /**
-     * @return the originate time as defined in RFC-1305
+     * @return the {@code originate} time as defined in RFC-1305
      */
     TimeStamp getOriginateTimeStamp();
 
@@ -98,7 +98,7 @@ public interface NtpV3Packet {
     int getPrecision();
 
     /**
-     * @return the receive time as defined in RFC-1305
+     * @return the {@code receive} time as defined in RFC-1305
      */
     TimeStamp getReceiveTimeStamp();
 
@@ -148,7 +148,7 @@ public interface NtpV3Packet {
     int getStratum();
 
     /**
-     * @return the transmit timestamp as defined in RFC-1305
+     * @return the {@code transmit} timestamp as defined in RFC-1305
      */
     TimeStamp getTransmitTimeStamp();
 
@@ -251,7 +251,7 @@ public interface NtpV3Packet {
     void setStratum(int stratum);
 
     /**
-     * Set the transmit timestamp given NTP TimeStamp object.
+     * Set the {@code transmit} timestamp given NTP TimeStamp object.
      *
      * @param ts - timestamp
      */

--- a/src/main/java/org/apache/commons/net/ntp/TimeInfo.java
+++ b/src/main/java/org/apache/commons/net/ntp/TimeInfo.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Wrapper class to network time packet messages (NTP, etc) that computes related timing info and stats.
+ * Wrapper class to network time packet messages (NTP, etc.) that computes related timing info and stats.
  */
 public class TimeInfo {
 
@@ -55,7 +55,7 @@ public class TimeInfo {
 
     /**
      * Create TimeInfo object with raw packet message and destination time received. Auto-computes details if computeDetails flag set otherwise this is delayed
-     * until computeDetails() is called. Delayed computation is for fast intialization when sub-millisecond timing is needed.
+     * until computeDetails() is called. Delayed computation is for fast initialization when sub-millisecond timing is needed.
      *
      * @param msgPacket        NTP message packet
      * @param returnTimeMillis destination receive time
@@ -80,7 +80,7 @@ public class TimeInfo {
 
     /**
      * Create TimeInfo object with raw packet message and destination time received. Auto-computes details if computeDetails flag set otherwise this is delayed
-     * until computeDetails() is called. Delayed computation is for fast intialization when sub-millisecond timing is needed.
+     * until computeDetails() is called. Delayed computation is for fast initialization when sub-millisecond timing is needed.
      *
      * @param message          NTP message packet
      * @param returnTimeMillis destination receive time

--- a/src/main/java/org/apache/commons/net/ntp/TimeStamp.java
+++ b/src/main/java/org/apache/commons/net/ntp/TimeStamp.java
@@ -109,7 +109,7 @@ public class TimeStamp implements Serializable, Comparable<TimeStamp> {
      */
 
     /**
-     * Helper method to convert Java time to NTP timestamp object. Note that Java time (milliseconds) by definition has less precision then NTP time
+     * Helper method to convert Java time to NTP timestamp object. Note that Java time (milliseconds) by definition has less precision than NTP time
      * (picoseconds) so converting Ntptime to Javatime and back to Ntptime loses precision. For example, Tue, Dec 17 2002 09:07:24.810 is represented by a
      * single Java-based time value of f22cd1fc8a, but its NTP equivalent are all values from c1a9ae1c.cf5c28f5 to c1a9ae1c.cf9db22c.
      *
@@ -123,7 +123,7 @@ public class TimeStamp implements Serializable, Comparable<TimeStamp> {
     /**
      * Converts 64-bit NTP timestamp to Java standard time.
      *
-     * Note that java time (milliseconds) by definition has less precision then NTP time (picoseconds) so converting NTP timestamp to java time and back to NTP
+     * Note that java time (milliseconds) by definition has less precision than NTP time (picoseconds) so converting NTP timestamp to java time and back to NTP
      * timestamp loses precision. For example, Tue, Dec 17 2002 09:07:24.810 EST is represented by a single Java-based time value of f22cd1fc8a, but its NTP
      * equivalent are all values ranging from c1a9ae1c.cf5c28f5 to c1a9ae1c.cf9db22c.
      *

--- a/src/main/java/org/apache/commons/net/pop3/ExtendedPOP3Client.java
+++ b/src/main/java/org/apache/commons/net/pop3/ExtendedPOP3Client.java
@@ -73,7 +73,7 @@ public class ExtendedPOP3Client extends POP3SClient {
      * <p>
      *
      * @param method   the {@link AUTH_METHOD} to use
-     * @param username the user name
+     * @param username the username
      * @param password the password
      * @return True if successfully completed, false if not.
      * @throws IOException              If an I/O error occurs while either sending a command to the server or receiving a reply from the server.

--- a/src/main/java/org/apache/commons/net/pop3/POP3.java
+++ b/src/main/java/org/apache/commons/net/pop3/POP3.java
@@ -67,7 +67,7 @@ public class POP3 extends SocketClient {
     static final String OK_INT = "+ ";
     static final String ERROR = "-ERR";
 
-    // We have to ensure that the protocol communication is in ASCII
+    // We have to ensure that the protocol communication is in ASCII,
     // but we use ISO-8859-1 just in case 8-bit characters cross
     // the wire.
     static final Charset DEFAULT_ENCODING = StandardCharsets.ISO_8859_1;
@@ -233,7 +233,7 @@ public class POP3 extends SocketClient {
      * Sends a command with no arguments to the server and returns the reply code.
      *
      * @param command The POP3 command to send (one of the POP3Command constants).
-     * @return The server reply code (either POP3Reply.OK, POP3Reply.ERROR or POP3Reply.OK_INT).
+     * @return The server reply code (either {@code POP3Reply.OK}, {@code POP3Reply.ERROR} or {@code POP3Reply.OK_INT}).
      * @throws IOException on error
      */
     public int sendCommand(final int command) throws IOException {
@@ -245,7 +245,7 @@ public class POP3 extends SocketClient {
      *
      * @param command The POP3 command to send (one of the POP3Command constants).
      * @param args    The command arguments.
-     * @return The server reply code (either POP3Reply.OK, POP3Reply.ERROR or POP3Reply.OK_INT).
+     * @return The server reply code (either {@code POP3Reply.OK}, {@code POP3Reply.ERROR} or {@code POP3Reply.OK_INT}).
      * @throws IOException on error
      */
     public int sendCommand(final int command, final String args) throws IOException {
@@ -256,7 +256,7 @@ public class POP3 extends SocketClient {
      * Sends a command with no arguments to the server and returns the reply code.
      *
      * @param command The POP3 command to send.
-     * @return The server reply code (either POP3Reply.OK, POP3Reply.ERROR or POP3Reply.OK_INT).
+     * @return The server reply code (either {@code POP3Reply.OK}, {@code POP3Reply.ERROR} or {@code POP3Reply.OK_INT}).
      * @throws IOException on error
      */
     public int sendCommand(final String command) throws IOException {
@@ -268,7 +268,7 @@ public class POP3 extends SocketClient {
      *
      * @param command The POP3 command to send.
      * @param args    The command arguments.
-     * @return The server reply code (either POP3Reply.OK, POP3Reply.ERROR or POP3Reply.OK_INT).
+     * @return The server reply code (either {@code POP3Reply.OK}, {@code POP3Reply.ERROR} or {@code POP3Reply.OK_INT}).
      * @throws IOException on error
      */
     public int sendCommand(final String command, final String args) throws IOException {

--- a/src/main/java/org/apache/commons/net/pop3/POP3Client.java
+++ b/src/main/java/org/apache/commons/net/pop3/POP3Client.java
@@ -115,9 +115,9 @@ public class POP3Client extends POP3 {
     }
 
     /**
-     * Delete a message from the POP3 server. The message is only marked for deletion by the server. If you decide to unmark the message, you must issuse a
-     * {@link #reset reset } command. Messages marked for deletion are only deleted by the server on {@link #logout logout }. A delete attempt can only succeed
-     * if the client is in the {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE } .
+     * Delete a message from the POP3 server. The message is only marked for deletion by the server. If you decide to unmark the message, you must issue a
+     * {@link #reset reset } command. Messages marked for deletion are only deleted by the server on {@link #logout logout }.
+     * A deletion attempt can only succeed if the client is in the {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE } .
      *
      * @param messageId The message number to delete.
      * @return True if the deletion attempt was successful, false if not.
@@ -230,9 +230,9 @@ public class POP3Client extends POP3 {
 
     /**
      * Login to the POP3 server with the given username and password. You must first connect to the server with
-     * {@link org.apache.commons.net.SocketClient#connect connect } before attempting to login. A login attempt is only valid if the client is in the
-     * {@link org.apache.commons.net.pop3.POP3#AUTHORIZATION_STATE AUTHORIZATION_STATE } . After logging in, the client enters the
-     * {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE } .
+     * {@link org.apache.commons.net.SocketClient#connect connect } before attempting to log in. A login attempt is only valid if the client is in the
+     * {@link org.apache.commons.net.pop3.POP3#AUTHORIZATION_STATE AUTHORIZATION_STATE }. After logging in, the client enters the
+     * {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE }.
      *
      * @param username The account name being logged in to.
      * @param password The plain text password of the account.
@@ -263,9 +263,9 @@ public class POP3Client extends POP3 {
      * the information. Therefore, after connecting to the server, you must call {@link org.apache.commons.net.pop3.POP3#getReplyString getReplyString } and
      * parse out the timestamp information yourself.
      * <p>
-     * You must first connect to the server with {@link org.apache.commons.net.SocketClient#connect connect } before attempting to login. A login attempt is
-     * only valid if the client is in the {@link org.apache.commons.net.pop3.POP3#AUTHORIZATION_STATE AUTHORIZATION_STATE } . After logging in, the client
-     * enters the {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE } . After connecting, you must parse out the server specific
+     * You must first connect to the server with {@link org.apache.commons.net.SocketClient#connect connect } before attempting to log in. A login attempt is
+     * only valid if the client is in the {@link org.apache.commons.net.pop3.POP3#AUTHORIZATION_STATE AUTHORIZATION_STATE }. After logging in, the client
+     * enters the {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE }. After connecting, you must parse out the server specific
      * information to use as a timestamp, and pass that information to this method. The secret is a shared secret known to you and the server. See RFC 1939 for
      * more details regarding the APOP command.
      *
@@ -331,7 +331,7 @@ public class POP3Client extends POP3 {
     }
 
     /**
-     * Send a NOOP command to the POP3 server. This is useful for keeping a connection alive since most POP3 servers will timeout after 10 minutes of
+     * Send a NOOP command to the POP3 server. This is useful for keeping a connection alive since most POP3 servers will time out after 10 minutes of
      * inactivity. A noop attempt will only succeed if the client is in the {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE } .
      *
      * @return True if the noop attempt was successful, false if not.
@@ -363,7 +363,7 @@ public class POP3Client extends POP3 {
      * {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE }
      * <p>
      * You must not issue any commands to the POP3 server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The POP3 protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
+     * instance. The POP3 protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader actually
      * reads directly from the POP3 connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
      * follow these requirements, your program will not work properly.
      *
@@ -389,9 +389,9 @@ public class POP3Client extends POP3 {
      * {@link org.apache.commons.net.pop3.POP3#TRANSACTION_STATE TRANSACTION_STATE }
      * <p>
      * You must not issue any commands to the POP3 server (i.e., call any other methods) until you finish reading the message from the returned BufferedReader
-     * instance. The POP3 protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned BufferedReader actually
-     * reads directly from the POP3 connection. After the end of message has been reached, new commands can be executed and their replies read. If you do not
-     * follow these requirements, your program will not work properly.
+     * instance. The POP3 protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned BufferedReader
+     * actually reads directly from the POP3 connection. After the end of message has been reached, new commands can be executed and their replies read.
+     * If you do not follow these requirements, your program will not work properly.
      *
      * @param messageId The number of the message to fetch.
      * @param numLines  The top number of lines to fetch. This must be &gt;= 0.

--- a/src/main/java/org/apache/commons/net/pop3/POP3Command.java
+++ b/src/main/java/org/apache/commons/net/pop3/POP3Command.java
@@ -24,7 +24,7 @@ package org.apache.commons.net.pop3;
  */
 
 public final class POP3Command {
-    /** Send user name. */
+    /** Send username. */
     public static final int USER = 0;
     /** Send password. */
     public static final int PASS = 1;

--- a/src/main/java/org/apache/commons/net/pop3/POP3SClient.java
+++ b/src/main/java/org/apache/commons/net/pop3/POP3SClient.java
@@ -80,7 +80,7 @@ public class POP3SClient extends POP3Client {
     /** The {@link HostnameVerifier} to use post-TLS, default null (i.e. no verification). */
     private HostnameVerifier hostnameVerifier;
 
-    /** Use Java 1.7+ HTTPS Endpoint Identification Algorithim. */
+    /** Use Java 1.7+ HTTPS Endpoint Identification Algorithm. */
     private boolean tlsEndpointChecking;
 
     /**
@@ -156,7 +156,7 @@ public class POP3SClient extends POP3Client {
 
     /**
      * Because there are so many connect() methods, the _connectAction_() method is provided as a means of performing some action immediately after establishing
-     * a connection, rather than reimplementing all of the connect() methods.
+     * a connection, rather than reimplementing all the connect() methods.
      *
      * @throws IOException If it is thrown by _connectAction_().
      * @see org.apache.commons.net.SocketClient#_connectAction_()

--- a/src/main/java/org/apache/commons/net/smtp/SMTP.java
+++ b/src/main/java/org/apache/commons/net/smtp/SMTP.java
@@ -40,7 +40,7 @@ import org.apache.commons.net.util.NetConstants;
  * You should keep in mind that the SMTP server may choose to prematurely close a connection for various reasons. The SMTP class will detect a premature SMTP
  * server connection closing when it receives a {@link org.apache.commons.net.smtp.SMTPReply#SERVICE_NOT_AVAILABLE SMTPReply.SERVICE_NOT_AVAILABLE } response to
  * a command. When that occurs, the SMTP class method encountering that reply will throw an {@link org.apache.commons.net.smtp.SMTPConnectionClosedException} .
- * <code>SMTPConectionClosedException</code> is a subclass of <code> IOException </code> and therefore need not be caught separately, but if you are going to
+ * <code>SMTPConnectionClosedException</code> is a subclass of <code> IOException </code> and therefore need not be caught separately, but if you are going to
  * catch it separately, its catch block must appear before the more general <code> IOException </code> catch block. When you encounter an
  * {@link org.apache.commons.net.smtp.SMTPConnectionClosedException} , you must disconnect the connection with
  * {@link org.apache.commons.net.SocketClient#disconnect disconnect() } to properly clean up the system resources used by SMTP. Before disconnecting, you may
@@ -61,7 +61,7 @@ public class SMTP extends SocketClient {
     /** The default SMTP port (25). */
     public static final int DEFAULT_PORT = 25;
 
-    // We have to ensure that the protocol communication is in ASCII
+    // We have to ensure that the protocol communication is in ASCII,
     // but we use ISO-8859-1 just in case 8-bit characters cross
     // the wire.
     private static final String DEFAULT_ENCODING = "ISO-8859-1";
@@ -97,7 +97,7 @@ public class SMTP extends SocketClient {
     /**
      * Overloaded constructor where the user may specify a default encoding.
      *
-     * @param encoding the encoing to use
+     * @param encoding the encoding to use
      * @since 2.0
      */
     public SMTP(final String encoding) {
@@ -336,7 +336,7 @@ public class SMTP extends SocketClient {
      * A convenience method to send the SMTP MAIL command to the server, receive the reply, and return the reply code.
      * <p>
      *
-     * @param reversePath The reverese path.
+     * @param reversePath The reverse path.
      * @return The reply code received from the server.
      * @throws SMTPConnectionClosedException If the SMTP server prematurely closes the connection as a result of the client being idle or some other reason
      *                                       causing the server to send SMTP reply code 421. This exception may be caught either as an IOException or
@@ -420,7 +420,7 @@ public class SMTP extends SocketClient {
      * A convenience method to send the SMTP SAML command to the server, receive the reply, and return the reply code.
      * <p>
      *
-     * @param reversePath The reverese path.
+     * @param reversePath The reverse path.
      * @return The reply code received from the server.
      * @throws SMTPConnectionClosedException If the SMTP server prematurely closes the connection as a result of the client being idle or some other reason
      *                                       causing the server to send SMTP reply code 421. This exception may be caught either as an IOException or
@@ -435,7 +435,7 @@ public class SMTP extends SocketClient {
      * A convenience method to send the SMTP SEND command to the server, receive the reply, and return the reply code.
      * <p>
      *
-     * @param reversePath The reverese path.
+     * @param reversePath The reverse path.
      * @return The reply code received from the server.
      * @throws SMTPConnectionClosedException If the SMTP server prematurely closes the connection as a result of the client being idle or some other reason
      *                                       causing the server to send SMTP reply code 421. This exception may be caught either as an IOException or
@@ -481,7 +481,7 @@ public class SMTP extends SocketClient {
 
     /**
      *
-     * @param command      the command to send (as an int defined in {@link SMPTCommand})
+     * @param command      the command to send (as an int defined in {@link SMTPCommand})
      * @param args         the command arguments, may be {@code null}
      * @param includeSpace if {@code true}, add a space between the command and its arguments
      * @return the reply code
@@ -559,7 +559,7 @@ public class SMTP extends SocketClient {
      * A convenience method to send the SMTP SOML command to the server, receive the reply, and return the reply code.
      * <p>
      *
-     * @param reversePath The reverese path.
+     * @param reversePath The reverse path.
      * @return The reply code received from the server.
      * @throws SMTPConnectionClosedException If the SMTP server prematurely closes the connection as a result of the client being idle or some other reason
      *                                       causing the server to send SMTP reply code 421. This exception may be caught either as an IOException or

--- a/src/main/java/org/apache/commons/net/smtp/SMTPClient.java
+++ b/src/main/java/org/apache/commons/net/smtp/SMTPClient.java
@@ -71,7 +71,7 @@ import org.apache.commons.net.io.DotTerminatedMessageWriter;
  * You should keep in mind that the SMTP server may choose to prematurely close a connection for various reasons. The SMTPClient class will detect a premature
  * SMTP server connection closing when it receives a {@link org.apache.commons.net.smtp.SMTPReply#SERVICE_NOT_AVAILABLE SMTPReply.SERVICE_NOT_AVAILABLE }
  * response to a command. When that occurs, the method encountering that reply will throw an {@link org.apache.commons.net.smtp.SMTPConnectionClosedException} .
- * <code>SMTPConectionClosedException</code> is a subclass of <code> IOException </code> and therefore need not be caught separately, but if you are going to
+ * <code>SMTPConnectionClosedException</code> is a subclass of <code> IOException </code> and therefore need not be caught separately, but if you are going to
  * catch it separately, its catch block must appear before the more general <code> IOException </code> catch block. When you encounter an
  * {@link org.apache.commons.net.smtp.SMTPConnectionClosedException} , you must disconnect the connection with {@link #disconnect disconnect() } to properly
  * clean up the system resources used by SMTPClient. Before disconnecting, you may check the last reply code and text with
@@ -206,7 +206,8 @@ public class SMTPClient extends SMTP {
     }
 
     /**
-     * Login to the SMTP server by sending the HELO command with the client hostname as an argument. Before performing any mail commands, you must first login.
+     * Login to the SMTP server by sending the {@code HELO} command with the client hostname as an argument.
+     * Before performing any mail commands, you must first log in.
      * <p>
      *
      * @return True if successfully completed, false if not.
@@ -230,7 +231,8 @@ public class SMTPClient extends SMTP {
     }
 
     /**
-     * Login to the SMTP server by sending the HELO command with the given hostname as an argument. Before performing any mail commands, you must first login.
+     * Login to the SMTP server by sending the {@code HELO} command with the given hostname as an argument.
+     * Before performing any mail commands, you must first log in.
      * <p>
      *
      * @param hostname The hostname with which to greet the SMTP server.
@@ -259,7 +261,7 @@ public class SMTPClient extends SMTP {
     }
 
     /**
-     * Aborts the current mail transaction, resetting all server stored sender, recipient, and mail data, cleaing all buffers and tables.
+     * Aborts the current mail transaction, resetting all server stored sender, recipient, and mail data, cleaning all buffers and tables.
      * <p>
      *
      * @return True if successfully completed, false if not.
@@ -277,7 +279,7 @@ public class SMTPClient extends SMTP {
      * written. Null is returned if the DATA command fails.
      * <p>
      * You must not issue any commands to the SMTP server (i.e., call any (other methods) until you finish writing to the returned Writer instance and close it.
-     * The SMTP protocol uses the same stream for issuing commands as it does for returning results. Therefore the returned Writer actually writes directly to
+     * The SMTP protocol uses the same stream for issuing commands as it does for returning results. Therefore, the returned Writer actually writes directly to
      * the SMTP connection. After you close the writer, you can execute new commands. If you do not follow these requirements your program will not work
      * properly.
      * <p>

--- a/src/main/java/org/apache/commons/net/smtp/SMTPCommand.java
+++ b/src/main/java/org/apache/commons/net/smtp/SMTPCommand.java
@@ -87,7 +87,7 @@ public final class SMTPCommand {
      * <p>
      *
      * @param command The command code.
-     * @return The SMTP protcol command string corresponding to a specified command code.
+     * @return The SMTP protocol command string corresponding to a specified command code.
      */
     public static String getCommand(final int command) {
         return commands[command];

--- a/src/main/java/org/apache/commons/net/smtp/SMTPReply.java
+++ b/src/main/java/org/apache/commons/net/smtp/SMTPReply.java
@@ -84,7 +84,7 @@ public final class SMTPReply {
 
     /**
      * Determine if a reply code is a positive intermediate response. All codes beginning with a 3 are positive intermediate responses. The SMTP server will
-     * send a positive intermediate response on the successful completion of one part of a multi-part sequence of commands. For example, after a successful DATA
+     * send a positive intermediate response on the successful completion of one part of a multipart sequence of commands. For example, after a successful DATA
      * command, a positive intermediate response will be sent to indicate that the server is ready to receive the message data.
      * <p>
      *
@@ -96,9 +96,9 @@ public final class SMTPReply {
     }
 
     /**
-     * Determine if a reply code is a positive preliminary response. All codes beginning with a 1 are positive preliminary responses. Postitive preliminary
+     * Determine if a reply code is a positive preliminary response. All codes beginning with a 1 are positive preliminary responses. Positive preliminary
      * responses are used to indicate tentative success. No further commands can be issued to the SMTP server after a positive preliminary response until a
-     * follow up response is received from the server.
+     * follow-up response is received from the server.
      * <p>
      * <b> Note: </b> <em> No SMTP commands defined in RFC 822 provide this type of reply. </em>
      * <p>

--- a/src/main/java/org/apache/commons/net/smtp/SMTPSClient.java
+++ b/src/main/java/org/apache/commons/net/smtp/SMTPSClient.java
@@ -90,7 +90,7 @@ public class SMTPSClient extends SMTPClient {
     /** The {@link HostnameVerifier} to use post-TLS, default null (i.e. no verification). */
     private HostnameVerifier hostnameVerifier;
 
-    /** Use Java 1.7+ HTTPS Endpoint Identification Algorithim. */
+    /** Use Java 1.7+ HTTPS Endpoint Identification Algorithm. */
     private boolean tlsEndpointChecking;
 
     /**
@@ -167,7 +167,7 @@ public class SMTPSClient extends SMTPClient {
 
     /**
      * Because there are so many connect() methods, the _connectAction_() method is provided as a means of performing some action immediately after establishing
-     * a connection, rather than reimplementing all of the connect() methods.
+     * a connection, rather than reimplementing all the connect() methods.
      *
      * @throws IOException If it is thrown by _connectAction_().
      * @see org.apache.commons.net.SocketClient#_connectAction_()

--- a/src/main/java/org/apache/commons/net/smtp/SimpleSMTPHeader.java
+++ b/src/main/java/org/apache/commons/net/smtp/SimpleSMTPHeader.java
@@ -25,7 +25,7 @@ import java.util.Locale;
  * This class is used to construct a bare minimum acceptable header for an email message. To construct more complicated headers you should refer to RFC 5322.
  * When the Java Mail API is finalized, you will be able to use it to compose fully compliant Internet text messages.
  * <p>
- * The main purpose of the class is to faciliatate the mail sending process, by relieving the programmer from having to explicitly format a simple message
+ * The main purpose of the class is to facilitate the mail sending process, by relieving the programmer from having to explicitly format a simple message
  * header. For example:
  *
  * <pre>
@@ -90,8 +90,9 @@ public class SimpleSMTPHeader {
     }
 
     /**
-     * Adds an arbitrary header field with the given value to the article header. These headers will be written before the From, To, Subject, and Cc fields when
-     * the SimpleSMTPHeader is convertered to a string. An example use would be:
+     * Adds an arbitrary header field with the given value to the article header. These headers will be written before the
+     * {@code From}, {@code To}, {@code Subject}, and {@code Cc} fields when the SimpleSMTPHeader is converted to a string.
+     * An example use would be:
      *
      * <pre>
      * header.addHeaderField("Organization", "Foobar, Inc.");

--- a/src/main/java/org/apache/commons/net/telnet/Telnet.java
+++ b/src/main/java/org/apache/commons/net/telnet/Telnet.java
@@ -193,7 +193,7 @@ class Telnet extends SocketClient {
 
     /* Code Section added for supporting AYT (start) */
     /**
-     * Sends an Are You There sequence and waits for the result.
+     * Sends an {@code Are You There (AYT)} sequence and waits for the result.
      *
      * @param timeout - Time to wait for a response (millis.)
      * @throws IOException              - Exception in I/O.
@@ -359,7 +359,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Processes a DO request.
+     * Processes a {@code DO} request.
      *
      * @param option - option code to be set.
      * @throws IOException - Exception in I/O.
@@ -425,7 +425,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Processes a DONT request.
+     * Processes a {@code DONT} request.
      *
      * @param option - option code to be set.
      * @throws IOException - Exception in I/O.
@@ -498,7 +498,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Processes a WILL request.
+     * Processes a {@code WILL} request.
      *
      * @param option - option code to be set.
      * @throws IOException - Exception in I/O.
@@ -549,7 +549,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Processes a WONT request.
+     * Processes a {@code WONT} request.
      *
      * @param option - option code to be set.
      * @throws IOException - Exception in I/O.
@@ -616,7 +616,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Requests a DONT.
+     * Requests a {@code DONT}.
      *
      * @param option - Option code.
      * @throws IOException - Exception in I/O.
@@ -633,7 +633,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a do has been reuqested
+     * @return returns true if a {@code DO} has been requested.
      *
      * @param option - option code to be looked up.
      */
@@ -644,7 +644,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a dont has been reuqested
+     * @return returns true if a {@code DONT} has been requested
      *
      * @param option - option code to be looked up.
      */
@@ -655,7 +655,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a will has been reuqested
+     * @return returns true if a {@code WILL} has been requested
      *
      * @param option - option code to be looked up.
      */
@@ -666,7 +666,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a wont has been reuqested
+     * @return returns true if a {@code WONT} has been requested
      *
      * @param option - option code to be looked up.
      */
@@ -675,7 +675,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Requests a WILL.
+     * Requests a {@code WILL}.
      *
      * @param option - Option code.
      * @throws IOException - Exception in I/O.
@@ -692,7 +692,7 @@ class Telnet extends SocketClient {
     /* TERMINAL-TYPE option (end) */
 
     /**
-     * Requests a WONT.
+     * Requests a {@code WONT}.
      *
      * @param option - Option code.
      * @throws IOException - Exception in I/O.
@@ -722,7 +722,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Sends a DO.
+     * Sends a {@code DO}.
      *
      * @param option - Option code.
      * @throws IOException - Exception in I/O.
@@ -740,7 +740,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Sends a DONT.
+     * Sends a {@code DONT}.
      *
      * @param option - Option code.
      * @throws IOException - Exception in I/O.
@@ -776,7 +776,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Sends a WILL.
+     * Sends a {@code WILL}.
      *
      * @param option - Option code.
      * @throws IOException - Exception in I/O.
@@ -794,7 +794,7 @@ class Telnet extends SocketClient {
     }
 
     /**
-     * Sends a WONT.
+     * Sends a {@code WONT}.
      *
      * @param option - Option code.
      * @throws IOException - Exception in I/O.
@@ -969,7 +969,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a do has been acknowledged
+     * @return returns true if a {@code DO} has been acknowledged.
      *
      * @param option - option code to be looked up.
      */
@@ -980,7 +980,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a dont has been acknowledged
+     * @return returns true if a {@code DONT} has been acknowledged
      *
      * @param option - option code to be looked up.
      */
@@ -991,7 +991,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a will has been acknowledged
+     * @return returns true if a {@code WILL} has been acknowledged
      *
      * @param option - option code to be looked up.
      */
@@ -1002,7 +1002,7 @@ class Telnet extends SocketClient {
     /**
      * Looks for the state of the option.
      *
-     * @return returns true if a wont has been acknowledged
+     * @return returns true if a {@code WONT} has been acknowledged
      *
      * @param option - option code to be looked up.
      */

--- a/src/main/java/org/apache/commons/net/telnet/TelnetClient.java
+++ b/src/main/java/org/apache/commons/net/telnet/TelnetClient.java
@@ -281,7 +281,7 @@ public class TelnetClient extends Telnet {
     }
 
     /**
-     * Sends an Are You There sequence and waits for the result.
+     * Sends an {@code Are You There (AYT)} sequence and waits for the result.
      *
      * @param timeout - Time to wait for a response (millis.)
      *

--- a/src/main/java/org/apache/commons/net/telnet/TelnetNotificationHandler.java
+++ b/src/main/java/org/apache/commons/net/telnet/TelnetNotificationHandler.java
@@ -31,29 +31,29 @@ public interface TelnetNotificationHandler {
     int RECEIVED_DO = 1;
 
     /**
-     * The remote party sent a DONT command.
+     * The remote party sent a {@code DONT} command.
      */
     int RECEIVED_DONT = 2;
 
     /**
-     * The remote party sent a WILL command.
+     * The remote party sent a {@code WILL} command.
      */
     int RECEIVED_WILL = 3;
 
     /**
-     * The remote party sent a WONT command.
+     * The remote party sent a {@code WONT} command.
      */
     int RECEIVED_WONT = 4;
 
     /**
-     * The remote party sent a COMMAND.
+     * The remote party sent a {@code COMMAND}.
      *
      * @since 2.2
      */
     int RECEIVED_COMMAND = 5;
 
     /**
-     * Callback method called when TelnetClient receives an command or option negotiation command
+     * Callback method called when TelnetClient receives a command or option negotiation command
      *
      * @param negotiation_code - type of (negotiation) command received (RECEIVED_DO, RECEIVED_DONT, RECEIVED_WILL, RECEIVED_WONT, RECEIVED_COMMAND)
      *

--- a/src/main/java/org/apache/commons/net/telnet/TelnetOptionHandler.java
+++ b/src/main/java/org/apache/commons/net/telnet/TelnetOptionHandler.java
@@ -64,10 +64,10 @@ public abstract class TelnetOptionHandler {
      * <p>
      *
      * @param optcode      - Option code.
-     * @param initlocal    - if set to true, a WILL is sent upon connection.
-     * @param initremote   - if set to true, a DO is sent upon connection.
-     * @param acceptlocal  - if set to true, any DO request is accepted.
-     * @param acceptremote - if set to true, any WILL request is accepted.
+     * @param initlocal    - if set to true, a {@code WILL} is sent upon connection.
+     * @param initremote   - if set to true, a {@code DO} is sent upon connection.
+     * @param acceptlocal  - if set to true, any {@code DO} request is accepted.
+     * @param acceptremote - if set to true, any {@code WILL} request is accepted.
      */
     public TelnetOptionHandler(final int optcode, final boolean initlocal, final boolean initremote, final boolean acceptlocal, final boolean acceptremote) {
         optionCode = optcode;
@@ -97,7 +97,7 @@ public abstract class TelnetOptionHandler {
      * Returns a boolean indicating whether to accept a DO request coming from the other end.
      * <p>
      *
-     * @return true if a DO request shall be accepted.
+     * @return true if a {@code DO} request shall be accepted.
      */
     public boolean getAcceptLocal() {
         return acceptLocal;
@@ -107,17 +107,17 @@ public abstract class TelnetOptionHandler {
      * Returns a boolean indicating whether to accept a WILL request coming from the other end.
      * <p>
      *
-     * @return true if a WILL request shall be accepted.
+     * @return true if a {@code WILL} request shall be accepted.
      */
     public boolean getAcceptRemote() {
         return acceptRemote;
     }
 
     /**
-     * Returns a boolean indicating whether a DO request sent to the other side has been acknowledged.
+     * Returns a boolean indicating whether a {@code DO} request sent to the other side has been acknowledged.
      * <p>
      *
-     * @return true if a DO sent to the other side has been acknowledged.
+     * @return true if a {@code DO} sent to the other side has been acknowledged.
      */
     boolean getDo() {
         return doFlag;
@@ -127,7 +127,7 @@ public abstract class TelnetOptionHandler {
      * Returns a boolean indicating whether to send a WILL request to the other end upon connection.
      * <p>
      *
-     * @return true if a WILL request shall be sent upon connection.
+     * @return true if a {@code WILL} request shall be sent upon connection.
      */
     public boolean getInitLocal() {
         return initialLocal;
@@ -137,7 +137,7 @@ public abstract class TelnetOptionHandler {
      * Returns a boolean indicating whether to send a DO request to the other end upon connection.
      * <p>
      *
-     * @return true if a DO request shall be sent upon connection.
+     * @return true if a {@code DO} request shall be sent upon connection.
      */
     public boolean getInitRemote() {
         return initialRemote;
@@ -154,10 +154,10 @@ public abstract class TelnetOptionHandler {
     }
 
     /**
-     * Returns a boolean indicating whether a WILL request sent to the other side has been acknowledged.
+     * Returns a boolean indicating whether a {@code WILL} request sent to the other side has been acknowledged.
      * <p>
      *
-     * @return true if a WILL sent to the other side has been acknowledged.
+     * @return true if a {@code WILL} sent to the other side has been acknowledged.
      */
     boolean getWill() {
         return willFlag;
@@ -174,50 +174,50 @@ public abstract class TelnetOptionHandler {
     }
 
     /**
-     * Set behavior of the option for WILL requests coming from the other end.
+     * Set behavior of the option for {@code WILL} requests coming from the other end.
      * <p>
      *
-     * @param accept - if true, subsequent WILL requests will be accepted.
+     * @param accept - if true, subsequent {@code WILL} requests will be accepted.
      */
     public void setAcceptRemote(final boolean accept) {
         acceptRemote = accept;
     }
 
     /**
-     * Tells this option whether a DO request sent to the other side has been acknowledged (invoked by TelnetClient).
+     * Tells this option whether a {@code DO} request sent to the other side has been acknowledged (invoked by TelnetClient).
      * <p>
      *
-     * @param state - if true, a DO request has been acknowledged.
+     * @param state - if true, a {@code DO} request has been acknowledged.
      */
     void setDo(final boolean state) {
         doFlag = state;
     }
 
     /**
-     * Tells this option whether to send a WILL request upon connection.
+     * Tells this option whether to send a {@code WILL} request upon connection.
      * <p>
      *
-     * @param init - if true, a WILL request will be sent upon subsequent connections.
+     * @param init - if true, a {@code WILL} request will be sent upon subsequent connections.
      */
     public void setInitLocal(final boolean init) {
         initialLocal = init;
     }
 
     /**
-     * Tells this option whether to send a DO request upon connection.
+     * Tells this option whether to send a {@code DO} request upon connection.
      * <p>
      *
-     * @param init - if true, a DO request will be sent upon subsequent connections.
+     * @param init - if true, a {@code DO} request will be sent upon subsequent connections.
      */
     public void setInitRemote(final boolean init) {
         initialRemote = init;
     }
 
     /**
-     * Tells this option whether a WILL request sent to the other side has been acknowledged (invoked by TelnetClient).
+     * Tells this option whether a {@code WILL} request sent to the other side has been acknowledged (invoked by TelnetClient).
      * <p>
      *
-     * @param state - if true, a WILL request has been acknowledged.
+     * @param state - if true, a {@code WILL} request has been acknowledged.
      */
     void setWill(final boolean state) {
         willFlag = state;
@@ -240,7 +240,7 @@ public abstract class TelnetOptionHandler {
      * This method is invoked whenever this option is acknowledged active on the remote end (TelnetClient sent a DO, remote side sent a WILL). The method is
      * used to specify a subnegotiation sequence that will be sent by TelnetClient when the option is activated.
      * <p>
-     * This implementation returns null, and must be overriden by the actual TelnetOptionHandler to specify which response must be sent for the subnegotiation
+     * This implementation returns null, and must be overridden by the actual TelnetOptionHandler to specify which response must be sent for the subnegotiation
      * request.
      *
      * @return subnegotiation sequence to be sent by TelnetClient. TelnetClient will add IAC SB &amp; IAC SE. null means no subnegotiation.

--- a/src/main/java/org/apache/commons/net/telnet/TelnetOutputStream.java
+++ b/src/main/java/org/apache/commons/net/telnet/TelnetOutputStream.java
@@ -25,7 +25,7 @@ import java.io.OutputStream;
  * <p>
  * In binary mode, the only conversion is to double IAC.
  * <p>
- * In ASCII mode, if convertCRtoCRLF is true (currently always true), any CR is converted to CRLF. IACs are doubled. Also a bare LF is converted to CRLF and a
+ * In ASCII mode, if convertCRtoCRLF is true (currently always true), any CR is converted to CRLF. IACs are doubled. Also, a bare LF is converted to CRLF and a
  * bare CR is converted to CR\0
  * <p>
  */

--- a/src/main/java/org/apache/commons/net/telnet/TerminalTypeOptionHandler.java
+++ b/src/main/java/org/apache/commons/net/telnet/TerminalTypeOptionHandler.java
@@ -58,10 +58,10 @@ public class TerminalTypeOptionHandler extends TelnetOptionHandler {
      * <p>
      *
      * @param termtype     - terminal type that will be negotiated.
-     * @param initlocal    - if set to true, a WILL is sent upon connection.
-     * @param initremote   - if set to true, a DO is sent upon connection.
-     * @param acceptlocal  - if set to true, any DO request is accepted.
-     * @param acceptremote - if set to true, any WILL request is accepted.
+     * @param initlocal    - if set to true, a {@code WILL} is sent upon connection.
+     * @param initremote   - if set to true, a {@code DO} is sent upon connection.
+     * @param acceptlocal  - if set to true, any {@code DO} request is accepted.
+     * @param acceptremote - if set to true, any {@code WILL} request is accepted.
      */
     public TerminalTypeOptionHandler(final String termtype, final boolean initlocal, final boolean initremote, final boolean acceptlocal,
             final boolean acceptremote) {

--- a/src/main/java/org/apache/commons/net/telnet/WindowSizeOptionHandler.java
+++ b/src/main/java/org/apache/commons/net/telnet/WindowSizeOptionHandler.java
@@ -59,10 +59,10 @@ public class WindowSizeOptionHandler extends TelnetOptionHandler {
      *
      * @param nWidth       - Window width.
      * @param nHeight      - Window Height
-     * @param initlocal    - if set to true, a WILL is sent upon connection.
-     * @param initremote   - if set to true, a DO is sent upon connection.
-     * @param acceptlocal  - if set to true, any DO request is accepted.
-     * @param acceptremote - if set to true, any WILL request is accepted.
+     * @param initlocal    - if set to true, a {@code WILL} is sent upon connection.
+     * @param initremote   - if set to true, a {@code DO} is sent upon connection.
+     * @param acceptlocal  - if set to true, any {@code DO} request is accepted.
+     * @param acceptremote - if set to true, any {@code WILL} request is accepted.
      */
     public WindowSizeOptionHandler(final int nWidth, final int nHeight, final boolean initlocal, final boolean initremote, final boolean acceptlocal,
             final boolean acceptremote) {

--- a/src/main/java/org/apache/commons/net/tftp/TFTP.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTP.java
@@ -133,7 +133,7 @@ public class TFTP extends DatagramSocketClient {
      * receive. To use these buffers you must call the bufferedReceive() and bufferedSend() methods instead of send() and receive(). You must also be certain
      * that you don't manipulate the resulting packet in such a way that it interferes with future buffered operations. For example, a TFTPDataPacket received
      * with bufferedReceive() will have a reference to the internal byte buffer. You must finish using this data before calling bufferedReceive() again, or else
-     * the data will be overwritten by the the call.
+     * the data will be overwritten by the call.
      *
      * @return The TFTPPacket received.
      * @throws InterruptedIOException If a socket timeout occurs. The Java documentation claims an InterruptedIOException is thrown on a DatagramSocket timeout,
@@ -159,7 +159,7 @@ public class TFTP extends DatagramSocketClient {
      * receive. To use these buffers you must call the bufferedReceive() and bufferedSend() methods instead of send() and receive(). You must also be certain
      * that you don't manipulate the resulting packet in such a way that it interferes with future buffered operations. For example, a TFTPDataPacket received
      * with bufferedReceive() will have a reference to the internal byte buffer. You must finish using this data before calling bufferedReceive() again, or else
-     * the data will be overwritten by the the call.
+     * the data will be overwritten by the call.
      *
      * @param packet The TFTP packet to send.
      * @throws IOException If some I/O error occurs.
@@ -189,7 +189,7 @@ public class TFTP extends DatagramSocketClient {
                 _socket_.receive(datagram);
             }
         } catch (final SocketException | InterruptedIOException e) {
-            // Do nothing. We timed out so we hope we're caught up.
+            // Do nothing. We timed out, so we hope we're caught up.
         }
 
         setSoTimeout(to);

--- a/src/main/java/org/apache/commons/net/tftp/TFTPAckPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPAckPacket.java
@@ -21,7 +21,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 
 /**
- * A final class derived from TFTPPacket definiing the TFTP Acknowledgement packet type.
+ * A final class derived from TFTPPacket defining the TFTP Acknowledgement packet type.
  * <p>
  * Details regarding the TFTP protocol and the format of TFTP packets can be found in RFC 783. But the point of these classes is to keep you from having to
  * worry about the internals. Additionally, only very few people should have to care about any of the TFTPPacket classes or derived classes. Almost all users
@@ -100,7 +100,7 @@ public final class TFTPAckPacket extends TFTPPacket {
     }
 
     /**
-     * This is a method only available within the package for implementing efficient datagram transport by elminating buffering. It takes a datagram as an
+     * This is a method only available within the package for implementing efficient datagram transport by eliminating buffering. It takes a datagram as an
      * argument, and a byte buffer in which to store the raw datagram data. Inside the method, the data is set as the datagram's data and the datagram returned.
      *
      * @param datagram The datagram to create.

--- a/src/main/java/org/apache/commons/net/tftp/TFTPClient.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPClient.java
@@ -47,7 +47,8 @@ import org.apache.commons.net.io.ToNetASCIIInputStream;
 
 public class TFTPClient extends TFTP {
     /**
-     * The default number of times a receive attempt is allowed to timeout before ending attempts to retry the receive and failing. The default is 5 timeouts.
+     * The default number of times a {@code receive} attempt is allowed to timeout before ending attempts to retry the {@code receive} and failing.
+     * The default is 5 timeouts.
      */
     public static final int DEFAULT_MAX_TIMEOUTS = 5;
 
@@ -69,7 +70,7 @@ public class TFTPClient extends TFTP {
     }
 
     /**
-     * Returns the maximum number of times a receive attempt is allowed to timeout before ending attempts to retry the receive and failing.
+     * Returns the maximum number of times a {@code receive} attempt is allowed to timeout before ending attempts to retry the {@code receive} and failing.
      *
      * @return The maximum number of timeouts allowed.
      */
@@ -433,8 +434,8 @@ public class TFTPClient extends TFTP {
     }
 
     /**
-     * Sets the maximum number of times a receive attempt is allowed to timeout during a receiveFile() or sendFile() operation before ending attempts to retry
-     * the receive and failing. The default is DEFAULT_MAX_TIMEOUTS.
+     * Sets the maximum number of times a {@code receive} attempt is allowed to timeout during a receiveFile() or sendFile() operation before ending
+     * attempts to retry the {@code receive} and failing. The default is DEFAULT_MAX_TIMEOUTS.
      *
      * @param numTimeouts The maximum number of timeouts to allow. Values less than 1 should not be used, but if they are, they are treated as 1.
      */

--- a/src/main/java/org/apache/commons/net/tftp/TFTPDataPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPDataPacket.java
@@ -21,7 +21,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 
 /**
- * A final class derived from TFTPPacket definiing the TFTP Data packet type.
+ * A final class derived from TFTPPacket defining the TFTP Data packet type.
  * <p>
  * Details regarding the TFTP protocol and the format of TFTP packets can be found in RFC 783. But the point of these classes is to keep you from having to
  * worry about the internals. Additionally, only very few people should have to care about any of the TFTPPacket classes or derived classes. Almost all users
@@ -163,7 +163,7 @@ public final class TFTPDataPacket extends TFTPPacket {
     }
 
     /**
-     * This is a method only available within the package for implementing efficient datagram transport by elminating buffering. It takes a datagram as an
+     * This is a method only available within the package for implementing efficient datagram transport by eliminating buffering. It takes a datagram as an
      * argument, and a byte buffer in which to store the raw datagram data. Inside the method, the data is set as the datagram's data and the datagram returned.
      *
      * @param datagram The datagram to create.

--- a/src/main/java/org/apache/commons/net/tftp/TFTPErrorPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPErrorPacket.java
@@ -21,7 +21,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 
 /**
- * A final class derived from TFTPPacket definiing the TFTP Error packet type.
+ * A final class derived from TFTPPacket defining the TFTP Error packet type.
  * <p>
  * Details regarding the TFTP protocol and the format of TFTP packets can be found in RFC 783. But the point of these classes is to keep you from having to
  * worry about the internals. Additionally, only very few people should have to care about any of the TFTPPacket classes or derived classes. Almost all users
@@ -165,7 +165,7 @@ public final class TFTPErrorPacket extends TFTPPacket {
     }
 
     /**
-     * This is a method only available within the package for implementing efficient datagram transport by elminating buffering. It takes a datagram as an
+     * This is a method only available within the package for implementing efficient datagram transport by eliminating buffering. It takes a datagram as an
      * argument, and a byte buffer in which to store the raw datagram data. Inside the method, the data is set as the datagram's data and the datagram returned.
      *
      * @param datagram The datagram to create.

--- a/src/main/java/org/apache/commons/net/tftp/TFTPPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPPacket.java
@@ -123,7 +123,7 @@ public abstract class TFTPPacket {
     InetAddress address;
 
     /**
-     * This constructor is not visible outside of the package. It is used by subclasses within the package to initialize base data.
+     * This constructor is not visible outside the package. It is used by subclasses within the package to initialize base data.
      *
      * @param type    The type of the packet.
      * @param address The host the packet came from or is going to be sent.
@@ -172,7 +172,7 @@ public abstract class TFTPPacket {
     public abstract DatagramPacket newDatagram();
 
     /**
-     * This is an abstract method only available within the package for implementing efficient datagram transport by elminating buffering. It takes a datagram
+     * This is an abstract method only available within the package for implementing efficient datagram transport by eliminating buffering. It takes a datagram
      * as an argument, and a byte buffer in which to store the raw datagram data. Inside the method, the data should be set as the datagram's data and the
      * datagram returned.
      *

--- a/src/main/java/org/apache/commons/net/tftp/TFTPReadRequestPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPReadRequestPacket.java
@@ -21,7 +21,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 
 /**
- * A class derived from TFTPRequestPacket definiing a TFTP read request packet type.
+ * A class derived from TFTPRequestPacket defining a TFTP read request packet type.
  * <p>
  * Details regarding the TFTP protocol and the format of TFTP packets can be found in RFC 783. But the point of these classes is to keep you from having to
  * worry about the internals. Additionally, only very few people should have to care about any of the TFTPPacket classes or derived classes. Almost all users

--- a/src/main/java/org/apache/commons/net/tftp/TFTPWriteRequestPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPWriteRequestPacket.java
@@ -21,7 +21,7 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 
 /**
- * A class derived from TFTPRequestPacket definiing a TFTP write request packet type.
+ * A class derived from TFTPRequestPacket defining a TFTP write request packet type.
  * <p>
  * Details regarding the TFTP protocol and the format of TFTP packets can be found in RFC 783. But the point of these classes is to keep you from having to
  * worry about the internals. Additionally, only very few people should have to care about any of the TFTPPacket classes or derived classes. Almost all users

--- a/src/main/java/org/apache/commons/net/time/TimeUDPClient.java
+++ b/src/main/java/org/apache/commons/net/time/TimeUDPClient.java
@@ -50,7 +50,7 @@ public final class TimeUDPClient extends DatagramSocketClient {
     /**
      * Same as <code> getTime(host, DEFAULT_PORT); </code>
      *
-     * @param host the time server
+     * @param host the time-server
      * @return the date
      * @throws IOException on error
      */
@@ -73,7 +73,7 @@ public final class TimeUDPClient extends DatagramSocketClient {
     /**
      * Same as <code> getTime(host, DEFAULT_PORT); </code>
      *
-     * @param host the time server
+     * @param host the time-server
      * @return the time returned from the server
      * @throws IOException on error
      */

--- a/src/main/java/org/apache/commons/net/util/Base64.java
+++ b/src/main/java/org/apache/commons/net/util/Base64.java
@@ -70,7 +70,7 @@ public class Base64 {
      * This array is a lookup table that translates 6-bit positive integer index values into their "Base64 Alphabet" equivalents as specified in Table 1 of RFC
      * 2045.
      *
-     * Thanks to "commons" project in ws.apache.org for this code. http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * Thanks to "commons" project in ws.apache.org for <a href="http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/">this code</a>.
      */
     private static final byte[] STANDARD_ENCODE_TABLE = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
             'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
@@ -96,7 +96,7 @@ public class Base64 {
      * Note: '+' and '-' both decode to 62. '/' and '_' both decode to 63. This means decoder seamlessly handles both URL_SAFE and STANDARD base64. (The
      * encoder, on the other hand, needs to know ahead of time what to emit).
      *
-     * Thanks to "commons" project in ws.apache.org for this code. http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * Thanks to "commons" project in ws.apache.org for <a href="http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/">this code</a>
      */
     private static final byte[] DECODE_TABLE = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, 62, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1,
@@ -336,7 +336,7 @@ public class Base64 {
     }
 
     /**
-     * Tests a given byte array to see if it contains only valid characters within the Base64 alphabet. Currently the method treats whitespace as valid.
+     * Tests a given byte array to see if it contains only valid characters within the Base64 alphabet. Currently, the method treats whitespace as valid.
      *
      * @param arrayOctet byte array to test
      * @return <code>true</code> if all bytes are valid characters in the Base64 alphabet or if the byte array is empty; false, otherwise
@@ -354,7 +354,7 @@ public class Base64 {
      * Returns whether or not the <code>octet</code> is in the base 64 alphabet.
      *
      * @param octet The value to test
-     * @return <code>true</code> if the value is defined in the the base 64 alphabet, <code>false</code> otherwise.
+     * @return <code>true</code> if the value is defined in the base 64 alphabet, <code>false</code> otherwise.
      * @since 1.4
      */
     public static boolean isBase64(final byte octet) {
@@ -416,7 +416,7 @@ public class Base64 {
 
     /**
      * Encode table to use: either STANDARD or URL_SAFE. Note: the DECODE_TABLE above remains static because it is able to decode both STANDARD and URL_SAFE
-     * streams, but the encodeTable must be a member variable so we can switch between the two modes.
+     * streams, but the encodeTable must be a member variable, so we can switch between the two modes.
      */
     private final byte[] encodeTable;
 
@@ -474,7 +474,7 @@ public class Base64 {
     private boolean eof;
 
     /**
-     * Place holder for the 3 bytes we're dealing with for our base64 logic. Bitwise operations store and extract the base64 encoding or decoding from this
+     * Placeholder for the 3 bytes we're dealing with for our base64 logic. Bitwise operations store and extract the base64 encoding or decoding from this
      * variable.
      */
     private int x;
@@ -522,8 +522,8 @@ public class Base64 {
      * When decoding all variants are supported.
      * </p>
      *
-     * @param lineLength Each line of encoded data will be at most of the given length (rounded down to nearest multiple of 4). If {@code lineLength <= 0}, then
-     *                   the output will not be divided into lines (chunks). Ignored when decoding.
+     * @param lineLength Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 4).
+     *                   If {@code lineLength <= 0}, then the output will not be divided into lines (chunks). Ignored when decoding.
      * @since 1.4
      */
     public Base64(final int lineLength) {
@@ -542,8 +542,8 @@ public class Base64 {
      * When decoding all variants are supported.
      * </p>
      *
-     * @param lineLength    Each line of encoded data will be at most of the given length (rounded down to nearest multiple of 4). If {@code lineLength <= 0},
-     *                      then the output will not be divided into lines (chunks). Ignored when decoding.
+     * @param lineLength    Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 4).
+     *                      If {@code lineLength <= 0}, then the output will not be divided into lines (chunks). Ignored when decoding.
      * @param lineSeparator Each line of encoded data will end with this sequence of bytes.
      * @throws IllegalArgumentException Thrown when the provided lineSeparator included some base64 characters.
      * @since 1.4
@@ -564,8 +564,8 @@ public class Base64 {
      * When decoding all variants are supported.
      * </p>
      *
-     * @param lineLength    Each line of encoded data will be at most of the given length (rounded down to nearest multiple of 4). If {@code lineLength <= 0},
-     *                      then the output will not be divided into lines (chunks). Ignored when decoding.
+     * @param lineLength    Each line of encoded data will be at most of the given length (rounded down to the nearest multiple of 4).
+     *                      If {@code lineLength <= 0}, then the output will not be divided into lines (chunks). Ignored when decoding.
      * @param lineSeparator Each line of encoded data will end with this sequence of bytes.
      * @param urlSafe       Instead of emitting '+' and '/' we emit '-' and '_' respectively. urlSafe is only applied to encode operations. Decoding seamlessly
      *                      handles both modes.
@@ -603,7 +603,7 @@ public class Base64 {
     }
 
     /**
-     * Decodes a byte[] containing containing characters in the Base64 alphabet.
+     * Decodes a byte[] containing characters in the Base64 alphabet.
      *
      * @param pArray A byte array containing Base64 character data
      * @return a byte array containing binary data
@@ -622,7 +622,7 @@ public class Base64 {
         // Would be nice to just return buf (like we sometimes do in the encode
         // logic), but we have no idea what the line-length was (could even be
         // variable). So we cannot determine ahead of time exactly how big an
-        // array is necessary. Hence the need to construct a 2nd byte array to
+        // array is necessary. Hence, the need to construct a 2nd byte array to
         // hold the final result:
 
         final byte[] result = new byte[pos];
@@ -641,7 +641,11 @@ public class Base64 {
      * </p>
      * <p>
      * Thanks to "commons" project in ws.apache.org for the bitwise operations, and general approach.
+     * <p>
+     * See: <a href="http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/">
      * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * </a>
+     *
      * </p>
      *
      * @param in      byte[] array of ascii data to base64 decode.
@@ -700,7 +704,7 @@ public class Base64 {
     }
 
     /**
-     * Decodes a String containing containing characters in the Base64 alphabet.
+     * Decodes a String containing characters in the Base64 alphabet.
      *
      * @param pArray A String containing Base64 character data
      * @return a byte array containing binary data
@@ -747,7 +751,10 @@ public class Base64 {
      * </p>
      * <p>
      * Thanks to "commons" project in ws.apache.org for the bitwise operations, and general approach.
+     * <p>
+     * See: <a href="http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/">
      * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * </a>
      * </p>
      *
      * @param in      byte[] array of binary data to base64 encode.

--- a/src/main/java/org/apache/commons/net/util/Charsets.java
+++ b/src/main/java/org/apache/commons/net/util/Charsets.java
@@ -20,7 +20,7 @@ package org.apache.commons.net.util;
 import java.nio.charset.Charset;
 
 /**
- * Helps dealing with Charsets.
+ * Helps to deal with Charsets.
  *
  * @since 3.3
  */

--- a/src/main/java/org/apache/commons/net/util/SSLContextUtils.java
+++ b/src/main/java/org/apache/commons/net/util/SSLContextUtils.java
@@ -35,7 +35,7 @@ public class SSLContextUtils {
     /**
      * Create and initialize an SSLContext.
      *
-     * @param protocol     the protocol used to instatiate the context
+     * @param protocol     the protocol used to instantiate the context
      * @param keyManager   the key manager, may be {@code null}
      * @param trustManager the trust manager, may be {@code null}
      * @return the initialized context.
@@ -49,7 +49,7 @@ public class SSLContextUtils {
     /**
      * Create and initialize an SSLContext.
      *
-     * @param protocol      the protocol used to instatiate the context
+     * @param protocol      the protocol used to instantiate the context
      * @param keyManagers   the array of key managers, may be {@code null} but array entries must not be {@code null}
      * @param trustManagers the array of trust managers, may be {@code null} but array entries must not be {@code null}
      * @return the initialized context.


### PR DESCRIPTION
Change
-
- fixes grammar issues in JavaDoc and code comments.
- fixes some typos found along the way.