### PR TITLE
Remove redundant (null) initializations

### DIFF
--- a/src/main/java/org/apache/commons/net/bsd/RCommandClient.java
+++ b/src/main/java/org/apache/commons/net/bsd/RCommandClient.java
@@ -114,8 +114,6 @@ public class RCommandClient extends RExecClient {
     public void connect(final InetAddress host, final int port, final InetAddress localAddr) throws SocketException, BindException, IOException {
         int localPort;
 
-        localPort = MAX_CLIENT_PORT;
-
         for (localPort = MAX_CLIENT_PORT; localPort >= MIN_CLIENT_PORT; --localPort) {
             try {
                 _socket_ = _socketFactory_.createSocket(host, port, localAddr, localPort);
@@ -221,7 +219,6 @@ public class RCommandClient extends RExecClient {
         int localPort;
         final Socket socket;
 
-        localPort = MAX_CLIENT_PORT;
         ServerSocket server = null;
 
         for (localPort = MAX_CLIENT_PORT; localPort >= MIN_CLIENT_PORT; --localPort) {

--- a/src/main/java/org/apache/commons/net/examples/ftp/TFTPExample.java
+++ b/src/main/java/org/apache/commons/net/examples/ftp/TFTPExample.java
@@ -155,7 +155,7 @@ public final class TFTPExample {
     private static boolean receive(final int transferMode, final String hostname, final String localFilename, final String remoteFilename,
             final TFTPClient tftp) {
         final boolean closed;
-        FileOutputStream output = null;
+        FileOutputStream output;
         final File file;
 
         file = new File(localFilename);
@@ -202,7 +202,7 @@ public final class TFTPExample {
 
     private static boolean send(final int transferMode, final String hostname, final String localFilename, final String remoteFilename, final TFTPClient tftp) {
         final boolean closed;
-        FileInputStream input = null;
+        FileInputStream input;
 
         // Try to open local file for reading
         try {

--- a/src/main/java/org/apache/commons/net/examples/mail/IMAPMail.java
+++ b/src/main/java/org/apache/commons/net/examples/mail/IMAPMail.java
@@ -68,7 +68,6 @@ public final class IMAPMail {
             System.out.println(imap.getReplyString());
             e.printStackTrace();
             System.exit(10);
-            return;
         } finally {
             imap.logout();
             imap.disconnect();

--- a/src/main/java/org/apache/commons/net/examples/mail/POP3ExportMbox.java
+++ b/src/main/java/org/apache/commons/net/examples/mail/POP3ExportMbox.java
@@ -149,7 +149,6 @@ public final class POP3ExportMbox {
             pop3.disconnect();
         } catch (final IOException e) {
             e.printStackTrace();
-            return;
         }
     }
 

--- a/src/main/java/org/apache/commons/net/examples/mail/POP3Mail.java
+++ b/src/main/java/org/apache/commons/net/examples/mail/POP3Mail.java
@@ -137,7 +137,6 @@ public final class POP3Mail {
             pop3.disconnect();
         } catch (final IOException e) {
             e.printStackTrace();
-            return;
         }
     }
 

--- a/src/main/java/org/apache/commons/net/examples/telnet/TelnetClientExample.java
+++ b/src/main/java/org/apache/commons/net/examples/telnet/TelnetClientExample.java
@@ -209,7 +209,7 @@ public class TelnetClientExample implements Runnable, TelnetNotificationHandler 
      */
     @Override
     public void receivedNegotiation(final int negotiation_code, final int option_code) {
-        String command = null;
+        String command;
         switch (negotiation_code) {
         case TelnetNotificationHandler.RECEIVED_DO:
             command = "DO";

--- a/src/main/java/org/apache/commons/net/ftp/FTP.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTP.java
@@ -575,7 +575,7 @@ public class FTP extends SocketClient {
             throw new MalformedServerReplyException("Truncated server reply: " + line);
         }
 
-        String code = null;
+        String code;
         try {
             code = line.substring(0, REPLY_CODE_LEN);
             _replyCode = Integer.parseInt(code);

--- a/src/main/java/org/apache/commons/net/ftp/FTPHTTPClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPHTTPClient.java
@@ -130,7 +130,7 @@ public class FTPHTTPClient extends FTPClient {
         }
 
         final boolean isInet6Address = getRemoteAddress() instanceof Inet6Address;
-        String passiveHost = null;
+        String passiveHost;
 
         final boolean attemptEPSV = isUseEPSVwithIPv4() || isInet6Address;
         if (attemptEPSV && epsv() == FTPReply.ENTERING_EPSV_MODE) {
@@ -212,7 +212,7 @@ public class FTPHTTPClient extends FTPClient {
             throw new IOException("No response from proxy");
         }
 
-        String code = null;
+        String code;
         final String resp = response.get(0);
         if (!resp.startsWith("HTTP/") || (resp.length() < 12)) {
             throw new IOException("Invalid response from proxy: " + resp);

--- a/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
@@ -150,7 +150,7 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
      */
     @Override
     public void configure(final FTPClientConfig config) {
-        DateFormatSymbols dfs = null;
+        DateFormatSymbols dfs;
 
         final String languageCode = config.getServerLanguageCode();
         final String shortmonths = config.getShortMonthNames();
@@ -262,7 +262,7 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
         final Calendar working = (Calendar) serverTime.clone();
         working.setTimeZone(getServerTimeZone()); // is this needed?
 
-        Date parsed = null;
+        Date parsed;
 
         if (recentDateFormat != null) {
             final Calendar now = (Calendar) serverTime.clone();// Copy this, because we may change it

--- a/src/main/java/org/apache/commons/net/ftp/parser/VMSVersioningFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/VMSVersioningFTPEntryParser.java
@@ -95,7 +95,7 @@ public class VMSVersioningFTPEntryParser extends VMSFTPEntryParser {
         final ListIterator<String> iter = original.listIterator();
         while (iter.hasNext()) {
             final String entry = iter.next().trim();
-            MatchResult result = null;
+            MatchResult result;
             final Matcher _preparse_matcher_ = preparsePattern.matcher(entry);
             if (_preparse_matcher_.matches()) {
                 result = _preparse_matcher_.toMatchResult();

--- a/src/main/java/org/apache/commons/net/nntp/NNTPClient.java
+++ b/src/main/java/org/apache/commons/net/nntp/NNTPClient.java
@@ -1173,12 +1173,12 @@ public class NNTPClient extends NNTP {
     /**
      * Private implementation of XHDR functionality.
      *
-     * See {@link NNTP#xhdr} for legal agument formats. Alternatively, read RFC 1036.
+     * See {@link NNTP#xhdr} for legal argument formats. Alternatively, read RFC 1036.
      * <p>
      *
      * @param header
      * @param articleRange
-     * @return Returns a DotTerminatedMessageReader if successful, null otherwise
+     * @return Returns a {@link DotTerminatedMessageReader} if successful, {@code null} otherwise
      * @throws IOException
      */
     private BufferedReader retrieveHeader(final String header, final String articleRange) throws IOException {

--- a/src/main/java/org/apache/commons/net/nntp/NewGroupsOrNewsQuery.java
+++ b/src/main/java/org/apache/commons/net/nntp/NewGroupsOrNewsQuery.java
@@ -184,7 +184,7 @@ public final class NewGroupsOrNewsQuery {
     }
 
     /**
-     * Return the NNTP query formatted date (year, month, day in the form YYMMDD.
+     * Return the NNTP query formatted date (year, month, day in the form YYMMDD).
      * <p>
      *
      * @return The NNTP query formatted date.
@@ -214,7 +214,7 @@ public final class NewGroupsOrNewsQuery {
     }
 
     /**
-     * Return the NNTP query formatted time (hour, minutes, seconds in the form HHMMSS.
+     * Return the NNTP query formatted time (hour, minutes, seconds in the form HHMMSS).
      * <p>
      *
      * @return The NNTP query formatted time.

--- a/src/main/java/org/apache/commons/net/tftp/TFTPPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPPacket.java
@@ -82,7 +82,7 @@ public abstract class TFTPPacket {
      */
     public static final TFTPPacket newTFTPPacket(final DatagramPacket datagram) throws TFTPPacketException {
         final byte[] data;
-        TFTPPacket packet = null;
+        TFTPPacket packet;
 
         if (datagram.getLength() < MIN_PACKET_SIZE) {
             throw new TFTPPacketException("Bad packet. Datagram data length is too short.");

--- a/src/main/java/org/apache/commons/net/util/Base64.java
+++ b/src/main/java/org/apache/commons/net/util/Base64.java
@@ -314,7 +314,7 @@ public class Base64 {
      * @param chunkSize      line-length of the output (<= 0 means no chunking) between each chunkSeparator (e.g. CRLF).
      * @param chunkSeparator the sequence of bytes used to separate chunks of output (e.g. CRLF).
      *
-     * @return amount of space needed to encoded the supplied array. Returns a long since a max-len array will require Integer.MAX_VALUE + 33%.
+     * @return amount of space needed to encode the supplied array. Returns a long since a max-len array will require Integer.MAX_VALUE + 33%.
      */
     private static long getEncodeLength(final byte[] pArray, int chunkSize, final byte[] chunkSeparator) {
         // base64 always encodes to multiples of 4.

--- a/src/test/java/org/apache/commons/net/ftp/AbstractFtpsTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/AbstractFtpsTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractFtpsTest {
      * @param userPropertiesResource resource path to user properties file.
      * @param serverJksResourceResource resource path to server JKS file.
      * @param defaultHome default home folder
-     * @throws FtpException Thrown when a the FTP classes cannot fulfill a request.
+     * @throws FtpException Thrown when the FTP classes cannot fulfill a request.
      */
     protected synchronized static void setupServer(final boolean implicit, final String userPropertiesResource, final String serverJksResourceResource, final String defaultHome)
             throws FtpException {

--- a/src/test/java/org/apache/commons/net/ftp/FTPClientConfigFunctionalTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/FTPClientConfigFunctionalTest.java
@@ -29,7 +29,7 @@ import junit.framework.TestCase;
  * setting. It is a perfect functional test for the Time Zone functionality of FTPClientConfig.
  *
  * A publicly accessible FTP server at the US National Oceanographic and Atmospheric Adminstration houses a directory which contains 300 files, named sn.0000 to
- * sn.0300. Every ten minutes or so the next file in sequence is rewritten with new data. Thus the directory contains observations for more than 24 hours of
+ * sn.0300. Every ten minutes or so the next file in sequence is rewritten with new data. Thus, the directory contains observations for more than 24 hours of
  * data. Since the server has its clock set to GMT this is an excellent functional test for any machine in a different time zone.
  *
  * Noteworthy is the fact that the FTP routines in some web browsers don't work as well as this. They can't, since they have no way of knowing the server's time

--- a/src/test/java/org/apache/commons/net/ftp/NoProtocolSslConfigurationProxy.java
+++ b/src/test/java/org/apache/commons/net/ftp/NoProtocolSslConfigurationProxy.java
@@ -26,7 +26,9 @@ import org.apache.ftpserver.ssl.ClientAuth;
 import org.apache.ftpserver.ssl.SslConfiguration;
 
 /**
- * see https://issues.apache.org/jira/browse/FTPSERVER-491
+ * See:
+ * <a href="https://issues.apache.org/jira/browse/FTPSERVER-491">
+ *   https://issues.apache.org/jira/browse/FTPSERVER-491</a>
  */
 public class NoProtocolSslConfigurationProxy implements SslConfiguration {
 

--- a/src/test/java/org/apache/commons/net/tftp/TFTPServer.java
+++ b/src/test/java/org/apache/commons/net/tftp/TFTPServer.java
@@ -733,8 +733,8 @@ public class TFTPServer implements Runnable {
      * Set the socket timeout in milliseconds used in transfers.
      * <p>
      * Defaults to the value {@link TFTP#DEFAULT_TIMEOUT} (5000 at the time I write this). Min value of 10.
-     *
-     * @param timeout the timeout; must be equal to or larger than 10
+     * </p>
+     * @param timeout the timeout; must be equal to or larger than 10.
      */
     public void setSocketTimeout(final int timeout) {
         if (timeout < 10) {

--- a/src/test/java/org/apache/commons/net/tftp/TFTPServer.java
+++ b/src/test/java/org/apache/commons/net/tftp/TFTPServer.java
@@ -730,10 +730,11 @@ public class TFTPServer implements Runnable {
     }
 
     /**
-     * Set the socket timeout in milliseconds used in transfers. Defaults to the value here:
-     * https://commons.apache.org/net/apidocs/org/apache/commons/net/tftp/TFTP.html#DEFAULT_TIMEOUT (5000 at the time I write this) Min value of 10.
+     * Set the socket timeout in milliseconds used in transfers.
+     * <p>
+     * Defaults to the value {@link TFTP#DEFAULT_TIMEOUT} (5000 at the time I write this). Min value of 10.
      *
-     * @param timeout the timeout; must be larger than 10
+     * @param timeout the timeout; must be equal to or larger than 10
      */
     public void setSocketTimeout(final int timeout) {
         if (timeout < 10) {


### PR DESCRIPTION
Change
-
- removes redundant (`null`) initializations
- removes non-required `return` statements in void methods 
- improves "text-only" URLs in JavaDoc
- fixes some typos and unpaired brackets along the path