### PR TITLE
Net constants refine

### DIFF
--- a/src/main/java/org/apache/commons/net/chargen/CharGenUDPClient.java
+++ b/src/main/java/org/apache/commons/net/chargen/CharGenUDPClient.java
@@ -62,7 +62,7 @@ public final class CharGenUDPClient extends DatagramSocketClient {
         // CharGen return packets have a maximum length of 512
         receiveData = new byte[512];
         receivePacket = new DatagramPacket(receiveData, receiveData.length);
-        sendPacket = new DatagramPacket(NetConstants.EMPTY_BTYE_ARRAY, 0);
+        sendPacket = new DatagramPacket(NetConstants.EMPTY_BYTE_ARRAY, 0);
     }
 
     /**

--- a/src/main/java/org/apache/commons/net/discard/DiscardUDPClient.java
+++ b/src/main/java/org/apache/commons/net/discard/DiscardUDPClient.java
@@ -39,7 +39,7 @@ public class DiscardUDPClient extends DatagramSocketClient {
     private final DatagramPacket sendPacket;
 
     public DiscardUDPClient() {
-        sendPacket = new DatagramPacket(NetConstants.EMPTY_BTYE_ARRAY, 0);
+        sendPacket = new DatagramPacket(NetConstants.EMPTY_BYTE_ARRAY, 0);
     }
 
     /**

--- a/src/main/java/org/apache/commons/net/echo/EchoUDPClient.java
+++ b/src/main/java/org/apache/commons/net/echo/EchoUDPClient.java
@@ -37,7 +37,7 @@ public final class EchoUDPClient extends DiscardUDPClient {
     /** The default echo port. It is set to 7 according to RFC 862. */
     public static final int DEFAULT_PORT = 7;
 
-    private final DatagramPacket receivePacket = new DatagramPacket(NetConstants.EMPTY_BTYE_ARRAY, 0);
+    private final DatagramPacket receivePacket = new DatagramPacket(NetConstants.EMPTY_BYTE_ARRAY, 0);
 
     /**
      * Same as <code> receive(data, data.length)</code>

--- a/src/main/java/org/apache/commons/net/util/Base64.java
+++ b/src/main/java/org/apache/commons/net/util/Base64.java
@@ -213,7 +213,7 @@ public class Base64 {
             return binaryData;
         }
 
-        final long len = getEncodeLength(binaryData, isChunked ? CHUNK_SIZE : 0, isChunked ? CHUNK_SEPARATOR : NetConstants.EMPTY_BTYE_ARRAY);
+        final long len = getEncodeLength(binaryData, isChunked ? CHUNK_SIZE : 0, isChunked ? CHUNK_SEPARATOR : NetConstants.EMPTY_BYTE_ARRAY);
         if (len > maxResultSize) {
             throw new IllegalArgumentException(
                     "Input array too big, the output array would be bigger (" + len + ") than the specified maxium size of " + maxResultSize);
@@ -575,7 +575,7 @@ public class Base64 {
     public Base64(int lineLength, byte[] lineSeparator, final boolean urlSafe) {
         if (lineSeparator == null) {
             lineLength = 0; // disable chunk-separating
-            lineSeparator = NetConstants.EMPTY_BTYE_ARRAY; // this just gets ignored
+            lineSeparator = NetConstants.EMPTY_BYTE_ARRAY; // this just gets ignored
         }
         this.lineLength = lineLength > 0 ? (lineLength / 4) * 4 : 0;
         this.lineSeparator = new byte[lineSeparator.length];

--- a/src/main/java/org/apache/commons/net/util/NetConstants.java
+++ b/src/main/java/org/apache/commons/net/util/NetConstants.java
@@ -23,7 +23,7 @@ import java.security.cert.X509Certificate;
  *
  * @since 3.8.0
  */
-public class NetConstants {
+public final class NetConstants {
 
     /**
      * An empty immutable {@code String} array.

--- a/src/main/java/org/apache/commons/net/util/NetConstants.java
+++ b/src/main/java/org/apache/commons/net/util/NetConstants.java
@@ -33,7 +33,7 @@ public final class NetConstants {
     /**
      * An empty immutable {@code byte} array.
      */
-    public static final byte[] EMPTY_BTYE_ARRAY = {};
+    public static final byte[] EMPTY_BYTE_ARRAY = {};
 
     /**
      * An empty immutable {link X509Certificate} array.


### PR DESCRIPTION
- Makes `org.apache.commons.net.util.NetConstants` `final` to prevent inheritance (utility class)
- Renames `org.apache.commons.net.util.NetConstants::EMPTY_BTYE_ARRAY` to `org.apache.commons.net.util.NetConstants::EMPTY_BYTE_ARRAY`

FYI @garydgregory @kinow 