### PR TITLE
Add Base64 missing tests and documentation fixes

### DIFF
--- a/src/main/java/org/apache/commons/net/util/Base64.java
+++ b/src/main/java/org/apache/commons/net/util/Base64.java
@@ -114,10 +114,10 @@ public class Base64 {
     // some state be preserved between calls of encode() and decode().
 
     /**
-     * Tests a given byte array to see if it contains only valid characters within the Base64 alphabet.
+     * Tests a given byte array to see if it contains any valid character within the Base64 alphabet.
      *
      * @param arrayOctet byte array to test
-     * @return {@code true} if any byte is a valid character in the Base64 alphabet; false herwise
+     * @return {@code true} if any byte is a valid character in the Base64 alphabet; {@code false} otherwise
      */
     private static boolean containsBase64Byte(final byte[] arrayOctet) {
         for (final byte element : arrayOctet) {
@@ -603,10 +603,10 @@ public class Base64 {
     }
 
     /**
-     * Decodes a byte[] containing characters in the Base64 alphabet.
+     * Decodes a byte array containing characters in the Base64 alphabet.
      *
      * @param pArray A byte array containing Base64 character data
-     * @return a byte array containing binary data
+     * @return a byte array containing binary data; will return {@code null} if provided byte array is null.
      */
     public byte[] decode(final byte[] pArray) {
         reset();
@@ -706,7 +706,7 @@ public class Base64 {
     /**
      * Decodes a String containing characters in the Base64 alphabet.
      *
-     * @param pArray A String containing Base64 character data
+     * @param pArray A String containing Base64 character data, must not be {@code null}
      * @return a byte array containing binary data
      * @since 1.4
      */

--- a/src/main/java/org/apache/commons/net/util/Base64.java
+++ b/src/main/java/org/apache/commons/net/util/Base64.java
@@ -606,7 +606,7 @@ public class Base64 {
      * Decodes a byte array containing characters in the Base64 alphabet.
      *
      * @param pArray A byte array containing Base64 character data
-     * @return a byte array containing binary data; will return {@code null} if provided byte array is null.
+     * @return a byte array containing binary data; will return {@code null} if provided byte array is {@code null}.
      */
     public byte[] decode(final byte[] pArray) {
         reset();

--- a/src/test/java/org/apache/commons/net/util/Base64Test.java
+++ b/src/test/java/org/apache/commons/net/util/Base64Test.java
@@ -21,11 +21,15 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
 
 public class Base64Test {
 
@@ -70,21 +74,37 @@ public class Base64Test {
     }
 
     @Test
-    @Ignore
     public void testDecodeBase64ByteArray() {
-        fail("Not yet implemented");
+        final byte[] base64Data = new byte[] {'b', 'G', 'l', 'n', 'a', 'H', 'Q', 'g', 'd', 'w', '=', '='};
+        final byte[] decoded = Base64.decodeBase64(base64Data);
+        assertEquals("light w", new String(decoded, StandardCharsets.UTF_8));
     }
 
     @Test
-    @Ignore
     public void testDecodeBase64String() {
-        fail("Not yet implemented");
+        final String base64Data = "bGlnaHQgdw==";
+        final byte[] decoded = Base64.decodeBase64(base64Data);
+        assertEquals("light w", new String(decoded, StandardCharsets.UTF_8));
     }
 
     @Test
-    @Ignore
     public void testDecodeByteArray() {
-        fail("Not yet implemented");
+        final byte[] base64Data = new byte[] {'Z', 'm', '9', 'v', 'Y', 'm', 'F', 'y'};
+        final byte[] decoded = new Base64().decode(base64Data);
+        assertEquals("foobar", new String(decoded, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testDecodeByteArrayNull() {
+        final byte[] decoded = new Base64().decode((byte[]) null);
+        assertNull(decoded);
+    }
+
+    @Test
+    public void testDecodeByteArrayEmpty() {
+        final byte[] base64Data = new byte[] {};
+        final byte[] decoded = new Base64().decode(base64Data);
+        assertArrayEquals(base64Data, decoded);
     }
 
     @Test
@@ -100,9 +120,16 @@ public class Base64Test {
     }
 
     @Test
-    @Ignore
     public void testDecodeString() {
-        fail("Not yet implemented");
+        final String base64String = "SGVsbG8gV29ybGQh";
+        final byte[] decoded = new Base64().decode(base64String);
+        assertEquals("Hello World!", new String(decoded));
+    }
+
+    @Test
+    public void testDecodeNullString() {
+        final Base64 base64 = new Base64();
+        assertThrows(NullPointerException.class, () -> base64.decode((String) null));
     }
 
     @Test
@@ -154,27 +181,33 @@ public class Base64Test {
     }
 
     @Test
-    @Ignore
     public void testEncodeBase64Chunked() {
-        fail("Not yet implemented");
+        final byte[] bytesToEncode = new byte[] {'f', 'o', 'o', 'b', 'a', 'r'};
+        final byte[] encodedData = Base64.encodeBase64Chunked(bytesToEncode);
+        assertEquals("Zm9vYmFy\r\n", new String(encodedData, StandardCharsets.UTF_8));
     }
 
     @Test
-    @Ignore
     public void testEncodeBase64StringByteArray() {
-        fail("Not yet implemented");
+        final String stringToEncode = "Many hands make light work.";
+        final String encodedData = Base64.encodeBase64String(stringToEncode.getBytes());
+        assertEquals("TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu\r\n", encodedData);
     }
 
     @Test
-    @Ignore
     public void testEncodeBase64StringByteArrayBoolean() {
-        fail("Not yet implemented");
+        final byte[] bytesToEncode = "light work.".getBytes();
+        final String chunkedResult = Base64.encodeBase64String(bytesToEncode, true);
+        assertEquals("bGlnaHQgd29yay4=\r\n", chunkedResult);
+        final String unchunkedResult = Base64.encodeBase64String(bytesToEncode, false);
+        assertEquals("bGlnaHQgd29yay4=", unchunkedResult);
     }
 
     @Test
-    @Ignore
     public void testEncodeBase64StringUnChunked() {
-        fail("Not yet implemented");
+        final byte[] bytesToEncode = "Many hands make light work.".getBytes();
+        final String encodedData = Base64.encodeBase64StringUnChunked(bytesToEncode);
+        assertEquals("TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu", encodedData);
     }
 
     @Test
@@ -208,9 +241,10 @@ public class Base64Test {
     }
 
     @Test
-    @Ignore
     public void testEncodeToString() {
-        fail("Not yet implemented");
+        final Base64 base64 = new Base64();
+        final byte[] bytesToEncode = new byte[] {'l', 'i', 'g', 'h', 't', ' ', 'w', 'o', 'r'};
+        assertEquals("bGlnaHQgd29y\r\n", base64.encodeToString(bytesToEncode));
     }
 
     @Test


### PR DESCRIPTION
- Adds missing tests for Base64 decoding and encoding (example Base64 data comes from [Base64 - Wikipedia](https://en.wikipedia.org/wiki/Base64) and [RFC - 4648](https://datatracker.ietf.org/doc/html/rfc4648))
- Updates Base64 documentation to reflect code and fixes some typos 

FYI @garydgregory @kinow 