### PR TITLE
Add FTPFile tests and fix Javadoc typos

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPFile.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPFile.java
@@ -289,6 +289,10 @@ public class FTPFile implements Serializable {
         return sb.toString();
     }
 
+    private void readObject(final java.io.ObjectInputStream in) {
+        throw new UnsupportedOperationException("Serialization is not supported");
+    }
+
     /**
      * Sets the name of the group owning the file. This may be a string representation of the group number.
      *
@@ -457,6 +461,10 @@ public class FTPFile implements Serializable {
         return sb.toString();
     }
 
+    /*
+     * Serialization is unnecessary for this class. Reject attempts to do so until such time as the Serializable attribute can be dropped.
+     */
+
     /**
      * Gets a string representation of the FTPFile information.
      * The returned output will be an FTP server raw listing.
@@ -468,14 +476,6 @@ public class FTPFile implements Serializable {
     @Override
     public String toString() {
         return getRawListing();
-    }
-
-    /*
-     * Serialization is unnecessary for this class. Reject attempts to do so until such time as the Serializable attribute can be dropped.
-     */
-
-    private void readObject(final java.io.ObjectInputStream in) {
-        throw new UnsupportedOperationException("Serialization is not supported");
     }
 
     private void writeObject(final java.io.ObjectOutputStream out) {

--- a/src/main/java/org/apache/commons/net/ftp/FTPFile.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPFile.java
@@ -410,7 +410,6 @@ public class FTPFile implements Serializable {
      * </p>
      *
      * @param timezone the time zone to use for displaying the time stamp If {@code null}, then use the Calendar ({@link #getTimestamp()}) entry
-     *
      * @return A string representation of the FTPFile information.
      * @since 3.4
      */
@@ -467,7 +466,7 @@ public class FTPFile implements Serializable {
 
     /**
      * Gets a string representation of the FTPFile information.
-     * The returned output will be an FTP server raw listing.
+     * Delegates to {@link #getRawListing()}
      *
      * @see #getRawListing()
      * @return A string representation of the FTPFile information.

--- a/src/main/java/org/apache/commons/net/ftp/FTPFile.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPFile.java
@@ -60,9 +60,8 @@ public class FTPFile implements Serializable {
 
     /** A constant indicating file/directory write permission. */
     public static final int WRITE_PERMISSION = 1;
-    /**
-     * A constant indicating file execute permission or directory listing permission.
-     */
+
+    /** A constant indicating file execute permission or directory listing permission. */
     public static final int EXECUTE_PERMISSION = 2;
 
     private int type = UNKNOWN_TYPE;
@@ -132,9 +131,10 @@ public class FTPFile implements Serializable {
     }
 
     /**
-     * If the FTPFile is a symbolic link, this method returns the name of the file being pointed to by the symbolic link. Otherwise, it returns null.
+     * If the FTPFile is a symbolic link, this method returns the name of the file being pointed to by the symbolic link.
+     * Otherwise, it returns {@code null}.
      *
-     * @return The file pointed to by the symbolic link (null if the FTPFile is not a symbolic link).
+     * @return The file pointed to by the symbolic link ({@code null} if the FTPFile is not a symbolic link).
      */
     public String getLink() {
         return link;
@@ -187,7 +187,7 @@ public class FTPFile implements Serializable {
     }
 
     /**
-     * Gets the type of the file (one of the <code>_TYPE</code> constants), e.g., if it is a directory, a regular file, or a symbolic link.
+     * Gets the type of the file (one of the {@code _TYPE} constants), e.g., if it is a directory, a regular file, or a symbolic link.
      *
      * @return The type of the file.
      */
@@ -205,13 +205,13 @@ public class FTPFile implements Serializable {
     }
 
     /**
-     * Tests if the given access group (one of the <code> _ACCESS </code> constants) has the given access permission (one of the <code> _PERMISSION </code>
+     * Tests if the given access group (one of the {@code _ACCESS} constants) has the given access permission (one of the {@code _PERMISSION}
      * constants) to the file.
      *
-     * @param access     The access group (one of the <code> _ACCESS </code> constants)
-     * @param permission The access permission (one of the <code> _PERMISSION </code> constants)
+     * @param access     The access group (one of the {@code _ACCESS} constants)
+     * @param permission The access permission (one of the {@code _PERMISSION} constants)
      * @throws ArrayIndexOutOfBoundsException if either of the parameters is out of range
-     * @return true if {@link #isValid()} is {@code true &&} the associated permission is set; {@code false} otherwise.
+     * @return {@code true} if {@link #isValid()} is {@code true} and the associated permission is set; {@code false} otherwise.
      */
     public boolean hasPermission(final int access, final int permission) {
         if (permissions == null) {
@@ -223,7 +223,7 @@ public class FTPFile implements Serializable {
     /**
      * Tests if the file is a directory.
      *
-     * @return True if the file is of type <code>DIRECTORY_TYPE</code>, false if not.
+     * @return {@code true} if the file is of type {@code DIRECTORY_TYPE}, {@code false} if not.
      */
     public boolean isDirectory() {
         return type == DIRECTORY_TYPE;
@@ -232,7 +232,7 @@ public class FTPFile implements Serializable {
     /**
      * Tests if the file is a regular file.
      *
-     * @return True if the file is of type <code>FILE_TYPE</code>, false if not.
+     * @return {@code true} if the file is of type {@code FILE_TYPE}, {@code false} if not.
      */
     public boolean isFile() {
         return type == FILE_TYPE;
@@ -241,7 +241,7 @@ public class FTPFile implements Serializable {
     /**
      * Tests if the file is a symbolic link.
      *
-     * @return True if the file is of type <code>UNKNOWN_TYPE</code>, false if not.
+     * @return {@code true} if the file is of type {@code SYMBOLIC_LINK_TYPE}, {@code false} if not.
      */
     public boolean isSymbolicLink() {
         return type == SYMBOLIC_LINK_TYPE;
@@ -250,7 +250,7 @@ public class FTPFile implements Serializable {
     /**
      * Tests if the type of the file is unknown.
      *
-     * @return True if the file is of type <code>UNKNOWN_TYPE</code>, false if not.
+     * @return {@code true} if the file is of type {@code UNKNOWN_TYPE}, {@code false} if not.
      */
     public boolean isUnknown() {
         return type == UNKNOWN_TYPE;
@@ -262,7 +262,7 @@ public class FTPFile implements Serializable {
      * Used in conjunction with list parsing that preserves entries that failed to parse.
      *
      * @see FTPClientConfig#setUnparseableEntries(boolean)
-     * @return true if the entry is valid
+     * @return {@code true} if the entry is valid; {@code false} otherwise
      * @since 3.4
      */
     public boolean isValid() {
@@ -287,10 +287,6 @@ public class FTPFile implements Serializable {
             sb.append('-');
         }
         return sb.toString();
-    }
-
-    private void readObject(final java.io.ObjectInputStream in) {
-        throw new UnsupportedOperationException("Serialization is not supported");
     }
 
     /**
@@ -330,13 +326,14 @@ public class FTPFile implements Serializable {
     }
 
     /**
-     * Sets if the given access group (one of the <code> _ACCESS </code> constants) has the given access permission (one of the <code> _PERMISSION </code>
+     * Sets if the given access group (one of the {@code _ACCESS} constants) has the given access permission (one of the {@code _PERMISSION}
      * constants) to the file.
      *
-     * @param access     The access group (one of the <code> _ACCESS </code> constants)
-     * @param permission The access permission (one of the <code> _PERMISSION </code> constants)
-     * @param value      True if permission is allowed, false if not.
+     * @param access     The access group (one of the {@code _ACCESS} constants)
+     * @param permission The access permission (one of the {@code _PERMISSION} constants)
+     * @param value      {@code true} if permission is allowed, {@code false} if not.
      * @throws ArrayIndexOutOfBoundsException if either of the parameters is out of range
+     * @throws NullPointerException if you're trying to set permission of an invalid file
      */
     public void setPermission(final int access, final int permission, final boolean value) {
         permissions[access][permission] = value;
@@ -370,7 +367,7 @@ public class FTPFile implements Serializable {
     }
 
     /**
-     * Sets the type of the file (<code>DIRECTORY_TYPE</code>, <code>FILE_TYPE</code>, etc.).
+     * Sets the type of the file ({@code DIRECTORY_TYPE}, {@code FILE_TYPE}, etc.).
      *
      * @param type The integer code representing the type of the file.
      */
@@ -408,7 +405,7 @@ public class FTPFile implements Serializable {
      * Note: if the instance is not valid {@link #isValid()}, no useful information can be returned. In this case, use {@link #getRawListing()} instead.
      * </p>
      *
-     * @param timezone the time zone to use for displaying the time stamp If {@code null}, then use the Calendar entry
+     * @param timezone the time zone to use for displaying the time stamp If {@code null}, then use the Calendar ({@link #getTimestamp()}) entry
      *
      * @return A string representation of the FTPFile information.
      * @since 3.4
@@ -460,18 +457,25 @@ public class FTPFile implements Serializable {
         return sb.toString();
     }
 
-    /*
-     * Serialization is unnecessary for this class. Reject attempts to do so until such time as the Serializable attribute can be dropped.
-     */
-
     /**
      * Gets a string representation of the FTPFile information.
+     * The returned output will be an FTP server raw listing.
+     *
+     * @see #getRawListing()
      *
      * @return A string representation of the FTPFile information.
      */
     @Override
     public String toString() {
         return getRawListing();
+    }
+
+    /*
+     * Serialization is unnecessary for this class. Reject attempts to do so until such time as the Serializable attribute can be dropped.
+     */
+
+    private void readObject(final java.io.ObjectInputStream in) {
+        throw new UnsupportedOperationException("Serialization is not supported");
     }
 
     private void writeObject(final java.io.ObjectOutputStream out) {

--- a/src/main/java/org/apache/commons/net/ftp/FTPFile.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPFile.java
@@ -337,9 +337,9 @@ public class FTPFile implements Serializable {
      * @param permission The access permission (one of the {@code _PERMISSION} constants)
      * @param value      {@code true} if permission is allowed, {@code false} if not.
      * @throws ArrayIndexOutOfBoundsException if either of the parameters is out of range
-     * @throws NullPointerException if you're trying to set permission of an invalid file
      */
     public void setPermission(final int access, final int permission, final boolean value) {
+        // TODO: only allow permission setting if file is valid
         permissions[access][permission] = value;
     }
 

--- a/src/main/java/org/apache/commons/net/ftp/FTPFile.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPFile.java
@@ -470,7 +470,6 @@ public class FTPFile implements Serializable {
      * The returned output will be an FTP server raw listing.
      *
      * @see #getRawListing()
-     *
      * @return A string representation of the FTPFile information.
      */
     @Override

--- a/src/test/java/org/apache/commons/net/ftp/FTPFileTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/FTPFileTest.java
@@ -1,0 +1,170 @@
+package org.apache.commons.net.ftp;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FTPFileTest {
+
+    @Test
+    public void testGetTimestampInstant() {
+        final FTPFile file = new FTPFile();
+        final Calendar timestamp = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        timestamp.set(2023, Calendar.AUGUST, 4, 23, 40, 55);
+        file.setTimestamp(timestamp);
+
+        final Instant timestampInstant = file.getTimestampInstant();
+
+        assertNotNull(timestampInstant);
+        final LocalDateTime fileDateTime = LocalDateTime.ofInstant(file.getTimestampInstant(), ZoneId.of("GMT"));
+        assertAll(
+                () -> assertEquals(2023, fileDateTime.getYear()),
+                () -> assertEquals(Month.AUGUST, fileDateTime.getMonth()),
+                () -> assertEquals(4, fileDateTime.getDayOfMonth()),
+                () -> assertEquals(23, fileDateTime.getHour()),
+                () -> assertEquals(40, fileDateTime.getMinute()),
+                () -> assertEquals(55, fileDateTime.getSecond())
+        );
+    }
+
+    @Test
+    public void testGetTimestampInstantNullCalendar() {
+        final FTPFile file = new FTPFile();
+        assertNull(file.getTimestampInstant());
+    }
+
+    @Test
+    public void testHasPermissionTrue() {
+        final FTPFile file = new FTPFile();
+        file.setPermission(FTPFile.USER_ACCESS, FTPFile.READ_PERMISSION, true);
+        assertTrue(file.hasPermission(FTPFile.USER_ACCESS, FTPFile.READ_PERMISSION));
+    }
+
+    @Test
+    public void testHasPermissionFalse() {
+        final FTPFile file = new FTPFile();
+        file.setPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION, false);
+        assertFalse(file.hasPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION));
+    }
+
+    @Test
+    public void testHasPermissionInvalidFile() {
+        final FTPFile invalidFile = new FTPFile("LIST");
+        assertFalse(invalidFile.hasPermission(FTPFile.GROUP_ACCESS, FTPFile.EXECUTE_PERMISSION));
+    }
+
+    @Test
+    public void testIsDirectory() {
+        final FTPFile file = new FTPFile();
+        file.setType(FTPFile.DIRECTORY_TYPE);
+        assertTrue(file.isDirectory());
+    }
+
+    @Test
+    public void testIsFile() {
+        final FTPFile file = new FTPFile();
+        file.setType(FTPFile.FILE_TYPE);
+        assertTrue(file.isFile());
+    }
+
+    @Test
+    public void testIsSymbolicLink() {
+        final FTPFile file = new FTPFile();
+        file.setType(FTPFile.SYMBOLIC_LINK_TYPE);
+        assertTrue(file.isSymbolicLink());
+    }
+
+    @Test
+    public void testIsUnknown() {
+        final FTPFile file = new FTPFile();
+        assertTrue(file.isUnknown());
+    }
+
+    @Test
+    public void toFormattedStringInvalidFile() {
+        final FTPFile invalidFile = new FTPFile("LIST");
+        assertEquals("[Invalid: could not parse file entry]", invalidFile.toFormattedString());
+    }
+
+    @Test
+    public void toFormattedStringUnknownType() {
+        final FTPFile file = new FTPFile();
+        assertTrue(file.toFormattedString().startsWith("?"));
+    }
+
+    @Test
+    public void toFormattedStringFileType() {
+        final FTPFile file = new FTPFile();
+        file.setType(FTPFile.FILE_TYPE);
+        assertTrue(file.toFormattedString().startsWith("-"));
+    }
+
+    @Test
+    public void toFormattedStringDirectoryType() {
+        final FTPFile file = new FTPFile();
+        file.setType(FTPFile.DIRECTORY_TYPE);
+        assertTrue(file.toFormattedString().startsWith("d"));
+    }
+
+    @Test
+    public void toFormattedStringSymbolicLinkType() {
+        final FTPFile file = new FTPFile();
+        file.setType(FTPFile.SYMBOLIC_LINK_TYPE);
+        assertTrue(file.toFormattedString().startsWith("l"));
+    }
+
+    @Test
+    public void toFormattedStringWithTimezone() {
+        final FTPFile file = new FTPFile();
+        file.setType(FTPFile.FILE_TYPE);
+        file.setSize(32767);
+        file.setUser("Apache");
+        file.setGroup("Apache Group");
+        file.setName("virus.bat");
+        final Calendar timestamp = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        timestamp.set(1969, Calendar.JULY, 16, 13, 32, 0);
+        file.setTimestamp(timestamp);
+        file.setPermission(FTPFile.USER_ACCESS, FTPFile.READ_PERMISSION, true);
+        file.setPermission(FTPFile.USER_ACCESS, FTPFile.WRITE_PERMISSION, true);
+        file.setPermission(FTPFile.USER_ACCESS, FTPFile.EXECUTE_PERMISSION, true);
+
+        final String formattedString = file.toFormattedString("GMT");
+
+        assertAll(
+                () -> assertTrue(formattedString.startsWith("-")),
+                () -> assertTrue(formattedString.startsWith("rwx", 1)),
+                () -> assertTrue(formattedString.contains(file.getUser())),
+                () -> assertTrue(formattedString.contains(file.getGroup())),
+                () -> assertTrue(formattedString.contains(String.valueOf(file.getSize()))),
+                () -> assertTrue(formattedString.contains("1969-07-16 13:32:00")),
+                () -> assertTrue(formattedString.contains("GMT")),
+                () -> assertTrue(formattedString.contains(file.getName()))
+        );
+    }
+
+    @Test
+    void testToStringDefault() {
+        final FTPFile file = new FTPFile();
+        assertNull(file.toString());
+    }
+
+    @Test
+    void testToString() {
+        final FTPFile file = new FTPFile();
+        file.setRawListing("LIST");
+        assertEquals(file.getRawListing(), file.toString());
+    }
+
+}

--- a/src/test/java/org/apache/commons/net/ftp/FTPFileTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/FTPFileTest.java
@@ -155,13 +155,13 @@ public class FTPFileTest {
     }
 
     @Test
-    void testToStringDefault() {
+    public void testToStringDefault() {
         final FTPFile file = new FTPFile();
         assertNull(file.toString());
     }
 
     @Test
-    void testToString() {
+    public void testToString() {
         final FTPFile file = new FTPFile();
         file.setRawListing("LIST");
         assertEquals(file.getRawListing(), file.toString());

--- a/src/test/java/org/apache/commons/net/ftp/FTPFileTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/FTPFileTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.commons.net.ftp;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- Fixed some typos in Javadoc and adjusted documentation to code
- Replaced HTML snippets with Javadoc counterparts
- Moved serialization-related methods under the "serialization comment"
- Adds FTPFile tests

FYI @kinow @garydgregory 