### PR TITLE
Add IMAP package tests, include junit-jupiter-params artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@ Supported protocols include: Echo, Finger, FTP, NNTP, NTP, POP3(S), SMTP(S), Tel
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftpserver-core</artifactId>
             <version>1.2.0</version>

--- a/src/main/java/org/apache/commons/net/imap/IMAPCommand.java
+++ b/src/main/java/org/apache/commons/net/imap/IMAPCommand.java
@@ -25,7 +25,6 @@ public enum IMAPCommand {
     // or must provide the correct string as the parameter.
 
     // Commands valid in any state:
-
     CAPABILITY(0), NOOP(0), LOGOUT(0),
 
     // Commands valid in Not Authenticated state
@@ -43,7 +42,7 @@ public enum IMAPCommand {
     /**
      * Get the IMAP protocol string command corresponding to a command code.
      *
-     * @param command the IMAPCommand whose command string is required.
+     * @param command the {@link IMAPCommand} whose command string is required. Must not be null.
      * @return The IMAP protocol string command corresponding to a command code.
      */
     public static final String getCommand(final IMAPCommand command) {
@@ -51,6 +50,7 @@ public enum IMAPCommand {
     }
 
     private final String imapCommand;
+
     @SuppressWarnings("unused") // not yet used
     private final int minParamCount;
 
@@ -84,7 +84,7 @@ public enum IMAPCommand {
     }
 
     /**
-     * Get the IMAP protocol string command for this command
+     * Returns the IMAP protocol string command for this command
      *
      * @return The IMAP protocol string command corresponding to this command
      */

--- a/src/main/java/org/apache/commons/net/imap/IMAPCommand.java
+++ b/src/main/java/org/apache/commons/net/imap/IMAPCommand.java
@@ -84,7 +84,7 @@ public enum IMAPCommand {
     }
 
     /**
-     * Returns the IMAP protocol string command for this command
+     * Gets the IMAP protocol string command for this command
      *
      * @return The IMAP protocol string command corresponding to this command
      */

--- a/src/test/java/org/apache/commons/net/imap/AuthenticatingIMAPClientTest.java
+++ b/src/test/java/org/apache/commons/net/imap/AuthenticatingIMAPClientTest.java
@@ -36,18 +36,6 @@ public class AuthenticatingIMAPClientTest {
         assertEquals(expectedAuthMethodName, authMethod.getAuthName());
     }
 
-    @Test
-    @Disabled("TODO: implement")
-    public void auth() {
-        fail("Not yet implemented");
-    }
-
-    @Test
-    @Disabled("TODO: implement")
-    public void authenticate() {
-        fail("Not yet implemented");
-    }
-
     private static Stream<Arguments> authMethods() {
         return Stream.of(
             Arguments.of("PLAIN", AuthenticatingIMAPClient.AUTH_METHOD.PLAIN),

--- a/src/test/java/org/apache/commons/net/imap/AuthenticatingIMAPClientTest.java
+++ b/src/test/java/org/apache/commons/net/imap/AuthenticatingIMAPClientTest.java
@@ -37,13 +37,13 @@ public class AuthenticatingIMAPClientTest {
     }
 
     @Test
-    @Disabled
+    @Disabled("TODO: implement")
     public void auth() {
         fail("Not yet implemented");
     }
 
     @Test
-    @Disabled
+    @Disabled("TODO: implement")
     public void authenticate() {
         fail("Not yet implemented");
     }

--- a/src/test/java/org/apache/commons/net/imap/AuthenticatingIMAPClientTest.java
+++ b/src/test/java/org/apache/commons/net/imap/AuthenticatingIMAPClientTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.net.imap;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class AuthenticatingIMAPClientTest {
+
+    @ParameterizedTest(name = "auth method for method {1} is `{0}`")
+    @MethodSource("authMethods")
+    public void getAuthName(final String expectedAuthMethodName, final AuthenticatingIMAPClient.AUTH_METHOD authMethod) {
+        assertEquals(expectedAuthMethodName, authMethod.getAuthName());
+    }
+
+    @Test
+    @Disabled
+    public void auth() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    @Disabled
+    public void authenticate() {
+        fail("Not yet implemented");
+    }
+
+    private static Stream<Arguments> authMethods() {
+        return Stream.of(
+            Arguments.of("PLAIN", AuthenticatingIMAPClient.AUTH_METHOD.PLAIN),
+            Arguments.of("CRAM-MD5", AuthenticatingIMAPClient.AUTH_METHOD.CRAM_MD5),
+            Arguments.of("LOGIN", AuthenticatingIMAPClient.AUTH_METHOD.LOGIN),
+            Arguments.of("XOAUTH", AuthenticatingIMAPClient.AUTH_METHOD.XOAUTH),
+            Arguments.of("XOAUTH2", AuthenticatingIMAPClient.AUTH_METHOD.XOAUTH2)
+        );
+    }
+
+}

--- a/src/test/java/org/apache/commons/net/imap/IMAPCommandTest.java
+++ b/src/test/java/org/apache/commons/net/imap/IMAPCommandTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.net.imap;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class IMAPCommandTest {
+
+    @ParameterizedTest(name = "Command for IMAPCommand::{1} should be `{0}`")
+    @MethodSource("imapCommands")
+    public void getCommand(final String expectedCommand, final IMAPCommand command) {
+        assertEquals(expectedCommand, IMAPCommand.getCommand(command));
+    }
+
+    private static Stream<Arguments> imapCommands() {
+        return Stream.of(
+                Arguments.of("CAPABILITY", IMAPCommand.CAPABILITY),
+                Arguments.of("NOOP", IMAPCommand.NOOP),
+                Arguments.of("LOGOUT", IMAPCommand.LOGOUT),
+                Arguments.of("STARTTLS", IMAPCommand.STARTTLS),
+                Arguments.of("AUTHENTICATE", IMAPCommand.AUTHENTICATE),
+                Arguments.of("LOGIN", IMAPCommand.LOGIN),
+                Arguments.of("XOAUTH", IMAPCommand.XOAUTH),
+                Arguments.of("SELECT", IMAPCommand.SELECT),
+                Arguments.of("EXAMINE", IMAPCommand.EXAMINE),
+                Arguments.of("CREATE", IMAPCommand.CREATE),
+                Arguments.of("DELETE", IMAPCommand.DELETE),
+                Arguments.of("RENAME", IMAPCommand.RENAME),
+                Arguments.of("SUBSCRIBE", IMAPCommand.SUBSCRIBE),
+                Arguments.of("UNSUBSCRIBE", IMAPCommand.UNSUBSCRIBE),
+                Arguments.of("LIST", IMAPCommand.LIST),
+                Arguments.of("LSUB", IMAPCommand.LSUB),
+                Arguments.of("STATUS", IMAPCommand.STATUS),
+                Arguments.of("APPEND", IMAPCommand.APPEND),
+                Arguments.of("CHECK", IMAPCommand.CHECK),
+                Arguments.of("CLOSE", IMAPCommand.CLOSE),
+                Arguments.of("EXPUNGE", IMAPCommand.EXPUNGE),
+                Arguments.of("SEARCH", IMAPCommand.SEARCH),
+                Arguments.of("FETCH", IMAPCommand.FETCH),
+                Arguments.of("STORE", IMAPCommand.STORE),
+                Arguments.of("COPY", IMAPCommand.COPY),
+                Arguments.of("UID", IMAPCommand.UID)
+        );
+    }
+
+}

--- a/src/test/java/org/apache/commons/net/imap/IMAPTest.java
+++ b/src/test/java/org/apache/commons/net/imap/IMAPTest.java
@@ -17,12 +17,80 @@
 
 package org.apache.commons.net.imap;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class IMAPTest {
+
+    @Test
+    public void trueChunkListener() {
+        assertTrue(IMAP.TRUE_CHUNK_LISTENER.chunkReceived(new IMAP()));
+    }
+
+    @Test
+    public void quoteMailboxNameNullInput() {
+        assertNull(IMAP.quoteMailboxName(null));
+    }
+
+    @Test
+    public void quoteMailboxNoQuotingIfNoSpacePresent() {
+        final String stringToQuote = "Foobar\"";
+        assertEquals(stringToQuote, IMAP.quoteMailboxName(stringToQuote));
+    }
+
+    @ParameterizedTest(name = "String `{0}` should be quoted")
+    @MethodSource("mailboxNamesToBeQuoted")
+    public void quoteMailboxName(final String input) {
+        final String quotedMailboxName = IMAP.quoteMailboxName(input);
+        assertAll(
+                () -> assertTrue(quotedMailboxName.startsWith("\""), "quoted string should start with quotation mark"),
+                () -> assertTrue(quotedMailboxName.endsWith("\""), "quoted string should end with quotation mark")
+        );
+    }
+
+    @Test
+    public void constructDefaultIMAP() {
+        final IMAP imap = new IMAP();
+        assertAll(
+                () -> assertEquals(IMAP.DEFAULT_PORT, imap.getDefaultPort()),
+                () -> assertEquals(IMAP.IMAPState.DISCONNECTED_STATE, imap.getState()),
+                () -> assertEquals(0, imap.getReplyStrings().length)
+        );
+    }
+
+    @Test
+    @Disabled("TODO: implement")
+    public void _connectAction_() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    @Disabled("TODO: implement")
+    public void disconnect() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    @Disabled("TODO: implement")
+    public void doCommand() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    @Disabled("TODO: implement")
+    public void fireReplyReceived() {
+        fail("Not yet implemented");
+    }
 
     @Test
     public void checkGenerator() {
@@ -48,4 +116,30 @@ public class IMAPTest {
         assertEquals(expected, i);
         assertTrue(matched, "Expected to see the original value again");
     }
+
+    @Test
+    @Disabled("TODO: implement")
+    public void getReplyString() {
+        fail("Not yet implemented");
+    }
+
+    @Test
+    @Disabled("TODO: implement")
+    public void getReplyStrings() {
+        fail("Not yet implemented");
+    }
+
+    private static Stream<String> mailboxNamesToBeQuoted() {
+        return Stream.of(
+                "",
+                " ",
+                "\"",
+                "\"\"",
+                "\\/  ",
+                "Hello\", ",
+                "\" World!",
+                "Hello\",\" World!"
+        );
+    }
+
 }

--- a/src/test/java/org/apache/commons/net/imap/IMAPTest.java
+++ b/src/test/java/org/apache/commons/net/imap/IMAPTest.java
@@ -69,30 +69,6 @@ public class IMAPTest {
     }
 
     @Test
-    @Disabled("TODO: implement")
-    public void _connectAction_() {
-        fail("Not yet implemented");
-    }
-
-    @Test
-    @Disabled("TODO: implement")
-    public void disconnect() {
-        fail("Not yet implemented");
-    }
-
-    @Test
-    @Disabled("TODO: implement")
-    public void doCommand() {
-        fail("Not yet implemented");
-    }
-
-    @Test
-    @Disabled("TODO: implement")
-    public void fireReplyReceived() {
-        fail("Not yet implemented");
-    }
-
-    @Test
     public void checkGenerator() {
         // This test assumes:
         // - 26 letters in the generator alphabet
@@ -115,18 +91,6 @@ public class IMAPTest {
         }
         assertEquals(expected, i);
         assertTrue(matched, "Expected to see the original value again");
-    }
-
-    @Test
-    @Disabled("TODO: implement")
-    public void getReplyString() {
-        fail("Not yet implemented");
-    }
-
-    @Test
-    @Disabled("TODO: implement")
-    public void getReplyStrings() {
-        fail("Not yet implemented");
     }
 
     private static Stream<String> mailboxNamesToBeQuoted() {


### PR DESCRIPTION
- Adds [junit-jupiter-params](https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-params) artifact
- Adds tests for various IMAP package classes that do not require a real (or mock) IMAP server
- Refactored IMAPReplyTest to use [ParameterizedTest](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests)

FYI @garydgregory @sebbASF @kinow