### PR TITLE
Change Class "org.apache.commons.net.ftp.parser.MVSFTPEntryParser" to support more datasets

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
@@ -193,7 +193,7 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      *
      * Other notes ===========
      *
-     * The file system supports automatically backup and retrieval of datasets. If a file is backed up, the ftp LIST command will return: ARCHIVE Not Direct
+     * The file system supports automatically backup and retrieval of datasets. If a file is backed up, the ftp LIST command will return: ARCIVE Not Direct
      * Access Device KJ.IOP998.ERROR.PL.UNITTEST
      *
      *
@@ -244,7 +244,7 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * Format of ZOS/MVS file list: 1 2 3 4 5 6 7 8 9 10
      * Volume Unit Referred Ext Used Recfm Lrecl BlkSz Dsorg Dsname
      * B10142 3390 2006/03/20 2 31 F 80 80 PS MDI.OKL.WORK
-     * ARCHIVE Not Direct Access Device KJ.IOP998.ERROR.PL.UNITTEST
+     * ARCIVE Not Direct Access Device KJ.IOP998.ERROR.PL.UNITTEST
      * B1N231 3390 2006/03/20 1 15 VB 256 27998 PO PLU
      * B1N231 3390 2006/03/20 1 15 VB 256 27998 PO-E PLB
      * Migrated                                                HLQ.DATASET.NAME
@@ -277,7 +277,7 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
             return file;
         }
 
-    	if (entry.startsWith("Migrated") || entry.startsWith("ARCHIVE")) {
+    	if (entry.startsWith("Migrated") || entry.startsWith("ARCIVE")) {
     		// Type of file is unknown for migrated datasets
             final FTPFile file = new FTPFile();
             file.setRawListing(entry);

--- a/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
@@ -252,7 +252,7 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
      * ----------------------------------- Group within Regex [1] Volume [2] Unit [3] Referred [4] Ext: number of extents [5] Used [6] Recfm: Record format [7]
      * Lrecl: Logical record length [8] BlkSz: Block size [9] Dsorg: Dataset organisation. Many exists but only support: PS, PO, PO-E [10] Dsname: Dataset name
      * <p>
-     * 
+     *
      * @param entry zosDirectoryEntry
      * @return null: entry was not parsed.
      */
@@ -277,8 +277,8 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
             return file;
         }
 
-    	if (entry.startsWith("Migrated") || entry.startsWith("ARCIVE")) {
-    		// Type of file is unknown for migrated datasets
+        if (entry.startsWith("Migrated") || entry.startsWith("ARCIVE")) {
+    	    // Type of file is unknown for migrated datasets
             final FTPFile file = new FTPFile();
             file.setRawListing(entry);
             file.setType(FTPFile.UNKNOWN_TYPE);

--- a/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
@@ -288,8 +288,9 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
             } else {
                file.setName(entry.split("\\s+")[5]);
             }
+
             return file;
-            }
+        }
 
         return null;
     }

--- a/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParser.java
@@ -278,18 +278,18 @@ public class MVSFTPEntryParser extends ConfigurableFTPFileEntryParserImpl {
         }
 
         if (entry.startsWith("Migrated") || entry.startsWith("ARCIVE")) {
-    	    // Type of file is unknown for migrated datasets
+            // Type of file is unknown for migrated datasets
             final FTPFile file = new FTPFile();
             file.setRawListing(entry);
             file.setType(FTPFile.UNKNOWN_TYPE);
-            
-            if (entry.startsWith("Migrated"))
-            	file.setName(entry.split("\\s+")[1]);
-            else 
-            	file.setName(entry.split("\\s+")[5]);
 
+            if (entry.startsWith("Migrated")) {
+               file.setName(entry.split("\\s+")[1]);
+            } else {
+               file.setName(entry.split("\\s+")[5]);
+            }
             return file;
-    	} 
+            }
 
         return null;
     }

--- a/src/test/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParserTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/MVSFTPEntryParserTest.java
@@ -34,14 +34,22 @@ public class MVSFTPEntryParserTest extends AbstractFTPParseTest {
             "SAVE00 3390   2004/06/23  1    1  FB     128  6144  PS    INCOMING.RPTBM023.D061704",
             "SAVE01 3390   2004/06/23  1    1  FB     128  6144  PO    INCOMING.RPTBM024.D061704",
             "SAVE02 3390   2004/06/23  1    1  FB     128  6144  PO-E  INCOMING.RPTBM025.D061704",
-            "PSMLC1 3390   2005/04/04  1    1  VB   27994 27998  PS    file3.I", "PSMLB9 3390   2005/04/04  1    1  VB   27994 27998  PS    file4.I.BU",
-            "PSMLB6 3390   2005/04/05  1    1  VB   27994 27998  PS    file3.I.BU", "PSMLC6 3390   2005/04/05  1    1  VB   27994 27998  PS    file6.I",
-            "PSMLB7 3390   2005/04/04  1    1  VB   27994 27998  PS    file7.O", "PSMLC6 3390   2005/04/05  1    1  VB   27994 27998  PS    file7.O.BU",
+            "PSMLC1 3390   2005/04/04  1    1  VB   27994 27998  PS    file3.I",
+            "PSMLB9 3390   2005/04/04  1    1  VB   27994 27998  PS    file4.I.BU",
+            "PSMLB6 3390   2005/04/05  1    1  VB   27994 27998  PS    file3.I.BU",
+            "PSMLC6 3390   2005/04/05  1    1  VB   27994 27998  PS    file6.I",
+            "PSMLB7 3390   2005/04/04  1    1  VB   27994 27998  PS    file7.O",
+            "PSMLC6 3390   2005/04/05  1    1  VB   27994 27998  PS    file7.O.BU",
             "FPFS49 3390   2004/06/23  1    1  FB     128  6144  PO-E  INCOMING.RPTBM026.D061704",
             "FPFS41 3390   2004/06/23  1    1  FB     128  6144  PS    INCOMING.RPTBM056.D061704",
             "FPFS25 3390   2004/06/23  1    1  FB     128  6144  PS    INCOMING.WTM204.D061704",
             "PEX26F 3390   2017/07/03  115807  FB   29600 29600  PS    INCOMING.FIN.D170630.T160630",
-            "VVVVVV 3390   2020/04/18 1    60   U   32760 32760  PO    NAME" };
+            "VVVVVV 3390   2020/04/18  1   60   U   32760 32760  PO    NAME", 
+            "TST017 3390   2023/09/08  2   59  FBA    133 32718  PO    NAME",
+            "TST063 3390   2023/09/11  1    1  VBA    133 27930  PS    NAME",
+            "Migrated                                                  NAME",
+            "ARCIVE Not Direct Access Device                           NAME"
+            };
 
     private static final String[] goodsamplesMemberList = {
             /* Note, if the string begins with SAVE, the parsed entry is stored in the List saveftpfiles */


### PR DESCRIPTION
Current MVSFTPEntryParser code doesn't support all possible datasets because some RECFM options (e.g. "FBA") are not listet in "static final String FILE_LIST_REGEX" (see also Jira-Ticket [NET-725](https://issues.apache.org/jira/browse/NET-725)). This PR should fix this problem. 

- RECFM (record format) of an MVS dataset is not a relevant information about a dataset. Therefore it should be ignored in definition of "static final String FILE_LIST_REGEX".
- Method "parseFileList(final String entry)" should also migrated and archived datasets.