### PR TITLE
NET-726 add protected getters to FTPSClient

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -1052,5 +1052,84 @@ public class FTPSClient extends FTPClient {
         }
     }
 
+    /**
+     * Gets the security mode. (True - Implicit Mode / False - Explicit Mode)
+     * @since 3.11.0
+     */
+    protected boolean isImplicit() {
+        return isImplicit;
+    }
+
+    /**
+     * Gets the secure socket protocol to be used, e.g. SSL/TLS.
+     * @since 3.11.0
+     */
+    protected String getProtocol() {
+        return protocol;
+    }
+
+    /**
+     * Gets the AUTH Command value.
+     * @since 3.11.0
+     */
+    protected String getAuth() {
+        return auth;
+    }
+
+    /**
+     * Gets whether a new SSL session may be established by this socket. Default true
+     * @since 3.11.0
+     */
+    protected boolean isCreation() {
+        return isCreation;
+    }
+
+    /**
+     * Gets the use client mode flag.
+     * @since 3.11.0
+     */
+    protected boolean isClientMode() {
+        return isClientMode;
+    }
+
+    /**
+     * Gets the need client auth flag.
+     * @since 3.11.0
+     */
+    protected boolean isNeedClientAuth() {
+        return isNeedClientAuth;
+    }
+
+    /**
+     * Gets the want client auth flag.
+     * @since 3.11.0
+     */
+    protected boolean isWantClientAuth() {
+        return isWantClientAuth;
+    }
+
+    /**
+     * Gets the cipher suites.
+     * @since 3.11.0
+     */
+    protected String[] getSuites() {
+        return suites;
+    }
+
+    /**
+     * Gets the protocol versions.
+     * @since 3.11.0
+     */
+    protected String[] getProtocols() {
+        return protocols;
+    }
+
+    /**
+     * Gets whether to use Java 1.7+ HTTPS Endpoint Identification Algorithm.
+     * @since 3.11.0
+     */
+    protected boolean isTlsEndpointChecking() {
+        return tlsEndpointChecking;
+    }
 }
 

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -1109,7 +1109,7 @@ public class FTPSClient extends FTPClient {
      * @since 3.11.0
      */
     protected String[] getSuites() {
-        return suites.clone();
+        return suites == null ? null : suites.clone();
     }
 
     /**
@@ -1118,7 +1118,7 @@ public class FTPSClient extends FTPClient {
      * @since 3.11.0
      */
     protected String[] getProtocols() {
-        return protocols.clone();
+        return protocols == null ? null : protocols.clone();
     }
 }
 

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -1069,14 +1069,6 @@ public class FTPSClient extends FTPClient {
     }
 
     /**
-     * Gets the AUTH Command value.
-     * @since 3.11.0
-     */
-    protected String getAuth() {
-        return auth;
-    }
-
-    /**
      * Gets whether a new SSL session may be established by this socket. Default true
      * @since 3.11.0
      */
@@ -1085,7 +1077,8 @@ public class FTPSClient extends FTPClient {
     }
 
     /**
-     * Gets the use client mode flag.
+     * Gets the use client mode flag. The {@link #getUseClientMode()} method gets the value from the socket while
+     * this method gets its value from this instance's config.
      * @since 3.11.0
      */
     protected boolean isClientMode() {
@@ -1093,7 +1086,8 @@ public class FTPSClient extends FTPClient {
     }
 
     /**
-     * Gets the need client auth flag.
+     * Gets the need client auth flag. The {@link #getNeedClientAuth()} method gets the value from the socket while
+     * this method gets its value from this instance's config.
      * @since 3.11.0
      */
     protected boolean isNeedClientAuth() {
@@ -1101,7 +1095,8 @@ public class FTPSClient extends FTPClient {
     }
 
     /**
-     * Gets the want client auth flag.
+     * Gets the want client auth flag. The {@link #getWantClientAuth()} method gets the value from the socket while
+     * this method gets its value from this instance's config.
      * @since 3.11.0
      */
     protected boolean isWantClientAuth() {
@@ -1109,7 +1104,8 @@ public class FTPSClient extends FTPClient {
     }
 
     /**
-     * Gets the cipher suites.
+     * Gets the cipher suites. The {@link #getEnabledCipherSuites()} method gets the value from the socket while
+     * this method gets its value from this instance's config.
      * @since 3.11.0
      */
     protected String[] getSuites() {
@@ -1117,19 +1113,12 @@ public class FTPSClient extends FTPClient {
     }
 
     /**
-     * Gets the protocol versions.
+     * Gets the protocol versions. The {@link #getEnabledProtocols()} method gets the value from the socket while
+     * this method gets its value from this instance's config.
      * @since 3.11.0
      */
     protected String[] getProtocols() {
         return protocols;
-    }
-
-    /**
-     * Gets whether to use Java 1.7+ HTTPS Endpoint Identification Algorithm.
-     * @since 3.11.0
-     */
-    protected boolean isTlsEndpointChecking() {
-        return tlsEndpointChecking;
     }
 }
 

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -1109,7 +1109,7 @@ public class FTPSClient extends FTPClient {
      * @since 3.11.0
      */
     protected String[] getSuites() {
-        return suites;
+        return suites.clone();
     }
 
     /**
@@ -1118,7 +1118,7 @@ public class FTPSClient extends FTPClient {
      * @since 3.11.0
      */
     protected String[] getProtocols() {
-        return protocols;
+        return protocols.clone();
     }
 }
 

--- a/src/test/java/org/apache/commons/net/ftp/FTPSClientGettersTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/FTPSClientGettersTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.net.ftp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the getters on {@link FTPSClient}.
+ */
+public class FTPSClientGettersTest {
+
+    @Test
+    public void testGetters() {
+        FTPSClient testClient = new FTPSClient("SSL", true);
+        assertTrue(testClient.isImplicit());
+        assertEquals("SSL", testClient.getProtocol());
+
+        FTPSClient testClient2 = new FTPSClient("TLS", false);
+        assertFalse(testClient2.isImplicit());
+        assertEquals("TLS", testClient2.getProtocol());
+        final String[] protocols = new String[]{"123", "456"};
+        testClient2.setEnabledProtocols(protocols);
+        assertArrayEquals(protocols, testClient2.getProtocols());
+        testClient2.setNeedClientAuth(true);
+        assertTrue(testClient2.isNeedClientAuth());
+        testClient2.setNeedClientAuth(false);
+        assertFalse(testClient2.isNeedClientAuth());
+        testClient2.setWantClientAuth(true);
+        assertTrue(testClient2.isWantClientAuth());
+        testClient2.setWantClientAuth(false);
+        assertFalse(testClient2.isWantClientAuth());
+        final String[] suites = new String[]{"abc", "def"};
+        testClient2.setEnabledCipherSuites(suites);
+        assertArrayEquals(suites, testClient2.getSuites());
+        testClient2.setAuthValue("qwerty");
+        assertEquals("qwerty", testClient2.getAuthValue());
+        testClient2.setUseClientMode(true);
+        assertTrue(testClient2.isClientMode());
+        testClient2.setUseClientMode(false);
+        assertFalse(testClient2.isClientMode());
+        testClient2.setEnabledSessionCreation(true);
+        assertTrue(testClient2.isCreation());
+        testClient2.setEnabledSessionCreation(false);
+        assertFalse(testClient2.isCreation());
+    }
+}
+


### PR DESCRIPTION
relates to https://issues.apache.org/jira/browse/NET-726

Aim is to make it easier to subclass FTPSClient.

I have only added protected getters for some private fields, ones with primitive or String return types. This is enough for my use case. More can be added, if the consensus is to add more.

I haven't changed the internal code to use the getters. Changing the internal code to use the getters means that subclasses could affect the values of the private fields by shadowing the related getter. This has pros and cons. If the consensus is to change the internal code of FTPSClient to access the fields via the new getters, I can make that change too.