### PR TITLE
Add SubnetAddressIterable & SubnetAddressIterator

### DIFF
--- a/src/main/java/org/apache/commons/net/util/SubnetUtils.java
+++ b/src/main/java/org/apache/commons/net/util/SubnetUtils.java
@@ -235,7 +235,6 @@ public class SubnetUtils {
         private final SubnetInfo subnetInfo;
 
         public SubnetAddressIterable(final SubnetInfo subnetInfo) {
-    
             this.subnetInfo = subnetInfo;
         }
 

--- a/src/main/java/org/apache/commons/net/util/SubnetUtils.java
+++ b/src/main/java/org/apache/commons/net/util/SubnetUtils.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.net.util;
 
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -220,6 +222,42 @@ public class SubnetUtils {
                 .append("  Address Count: [").append(getAddressCountLong()).append("]\n");
             // @formatter:on
             return buf.toString();
+        }
+    }
+
+    public static class SubnetAddressIterable implements Iterable<String> {
+        private final SubnetInfo subnetInfo;
+
+        public SubnetAddressIterable(SubnetInfo subnetInfo) {
+            this.subnetInfo = subnetInfo;
+        }
+
+        @Override
+        public Iterator<String> iterator() {
+            return new SubnetAddressIterator(subnetInfo);
+        }
+    }
+
+    public static class SubnetAddressIterator implements Iterator<String> {
+        private final SubnetInfo subnetInfo;
+
+        private final AtomicInteger currentAddress;
+
+        public SubnetAddressIterator(SubnetInfo subnetInfo) {
+            this.subnetInfo = subnetInfo;
+            currentAddress = new AtomicInteger(subnetInfo.low());
+        }
+
+        @Override
+        public boolean hasNext() {
+            return subnetInfo.getAddressCount() > 0 && currentAddress.get() <= subnetInfo.high();
+        }
+
+        @Override
+        public String next() {
+            String address = subnetInfo.format(subnetInfo.toArray(currentAddress.get()));
+            currentAddress.incrementAndGet();
+            return address;
         }
     }
 

--- a/src/main/java/org/apache/commons/net/util/SubnetUtils.java
+++ b/src/main/java/org/apache/commons/net/util/SubnetUtils.java
@@ -225,10 +225,17 @@ public class SubnetUtils {
         }
     }
 
+    /**
+     * Allows an object to be the target of the "for-each loop" statement for a SubnetInfo.
+     *
+     * @since 3.12.0
+     */
     public static class SubnetAddressIterable implements Iterable<String> {
+
         private final SubnetInfo subnetInfo;
 
-        public SubnetAddressIterable(SubnetInfo subnetInfo) {
+        public SubnetAddressIterable(final SubnetInfo subnetInfo) {
+    
             this.subnetInfo = subnetInfo;
         }
 
@@ -238,12 +245,18 @@ public class SubnetUtils {
         }
     }
 
+    /**
+     * Iterates over a SubnetInfo.
+     *
+     * @since 3.12.0
+     */
     public static class SubnetAddressIterator implements Iterator<String> {
+
         private final SubnetInfo subnetInfo;
 
         private final AtomicInteger currentAddress;
 
-        public SubnetAddressIterator(SubnetInfo subnetInfo) {
+        public SubnetAddressIterator(final SubnetInfo subnetInfo) {
             this.subnetInfo = subnetInfo;
             currentAddress = new AtomicInteger(subnetInfo.low());
         }

--- a/src/test/java/org/apache/commons/net/SubnetUtilsTest.java
+++ b/src/test/java/org/apache/commons/net/SubnetUtilsTest.java
@@ -29,6 +29,9 @@ import org.apache.commons.net.util.SubnetUtils;
 import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @SuppressWarnings("deprecation") // deliberate use of deprecated methods
 public class SubnetUtilsTest {
 
@@ -405,6 +408,21 @@ public class SubnetUtilsTest {
             assertEquals(lowAd[i], info.getLowAddress(), "lo " + masks[i]);
             assertEquals(highA[i], info.getHighAddress(), "hi " + masks[i]);
         }
+    }
+
+    @Test
+    public void testSubnetAddressIterable() {
+        SubnetUtils utils = new SubnetUtils("192.168.1.0/24");
+        List<String> addressList = new ArrayList<>();
+        for (String address : new SubnetUtils.SubnetAddressIterable(utils.getInfo())) {
+            addressList.add(address);
+        }
+        assertEquals(254, addressList.size());
+        assertFalse(addressList.contains("192.168.1.0"));
+        assertTrue(addressList.contains("192.168.1.1"));
+        assertTrue(addressList.contains("192.168.1.127"));
+        assertTrue(addressList.contains("192.168.1.254"));
+        assertFalse(addressList.contains("192.168.1.255"));
     }
 
     @Test


### PR DESCRIPTION
org.apache.commons.net.util.SubnetUtils.SubnetInfo#getAllAddresses method may take too much memory when dealing with subnet like "1.0.0.0/8", so add SubnetAddressIterable & SubnetAddressIterator to implement similar function.