### PR TITLE
NET-727 enable accessing options map for TFTP request packet

### DIFF
--- a/src/main/java/org/apache/commons/net/tftp/TFTPErrorPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPErrorPacket.java
@@ -62,6 +62,9 @@ public final class TFTPErrorPacket extends TFTPPacket {
     /** The no such user error code according to RFC 783, value 7. */
     public static final int NO_SUCH_USER = 7;
 
+    /** The invalid options error code according to RFC 2347, value 8. */
+    public static final int INVALID_OPTIONS_VALUE = 8;
+
     /** The error code of this packet. */
     private final int error;
 

--- a/src/main/java/org/apache/commons/net/tftp/TFTPRequestPacket.java
+++ b/src/main/java/org/apache/commons/net/tftp/TFTPRequestPacket.java
@@ -60,7 +60,7 @@ public abstract class TFTPRequestPacket extends TFTPPacket {
     private final String fileName;
 
     /** The option values */
-    private Map<String, String> options = new HashMap<>();
+    private final Map<String, String> options = new HashMap<>();
 
     /**
      * Creates a request packet of a given type to be sent to a host at a given port with a file name and transfer mode request.

--- a/src/test/java/org/apache/commons/net/tftp/TFTPRequestPacketTest.java
+++ b/src/test/java/org/apache/commons/net/tftp/TFTPRequestPacketTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.net.tftp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests {@link TFTPRequestPacket}.
+ */
+class TFTPRequestPacketTest {
+
+    @Test
+    public void testGetOptions() throws UnknownHostException, TFTPPacketException {
+        DatagramPacket datagramPacket = getDatagramPacket();
+        TFTPReadRequestPacket requestPacket = new TFTPReadRequestPacket(datagramPacket);
+        assertNotNull(requestPacket.toString());
+        Map<String, String> options = requestPacket.getOptions();
+        assertEquals(1, options.size());
+        assertEquals("1024", options.get("blksize"));
+    }
+
+    @Test
+    public void testNewDatagram() throws TFTPPacketException, UnknownHostException {
+        DatagramPacket datagramPacket = getDatagramPacket();
+
+        TFTPReadRequestPacket requestPacket = new TFTPReadRequestPacket(datagramPacket);
+        DatagramPacket newDatagram = requestPacket.newDatagram();
+
+        assertNotNull(newDatagram);
+        assertEquals(datagramPacket.getAddress(), newDatagram.getAddress());
+        assertEquals(datagramPacket.getPort(), newDatagram.getPort());
+        assertEquals(datagramPacket.getLength(), newDatagram.getLength());
+        assertArrayEquals(datagramPacket.getData(), newDatagram.getData());
+
+        byte[] data = new byte[datagramPacket.getLength()];
+        DatagramPacket newDatagram2 = new DatagramPacket(data, data.length, InetAddress.getLocalHost(), 0);
+        requestPacket.newDatagram(newDatagram2, data);
+
+        assertEquals(datagramPacket.getAddress(), newDatagram2.getAddress());
+        assertEquals(datagramPacket.getPort(), newDatagram2.getPort());
+        assertArrayEquals(datagramPacket.getData(), data);
+    }
+
+    private static DatagramPacket getDatagramPacket() throws UnknownHostException {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        byteStream.write(0);
+        byteStream.write(1);
+
+        try {
+            byteStream.write("fileName".getBytes(StandardCharsets.US_ASCII));
+            byteStream.write(0);
+            byteStream.write("octet".getBytes(StandardCharsets.US_ASCII));
+            byteStream.write(0);
+
+            byteStream.write("blksize".getBytes(StandardCharsets.US_ASCII));
+            byteStream.write(0);
+            byteStream.write("1024".getBytes(StandardCharsets.US_ASCII));
+            byteStream.write(0);
+        } catch (IOException e) {
+            throw new RuntimeException("Error creating TFTP request packet", e);
+        }
+
+        byte[] data = byteStream.toByteArray();
+        return new DatagramPacket(data, data.length, InetAddress.getLocalHost(), 0);
+    }
+}


### PR DESCRIPTION
relates to existing  https://issues.apache.org/jira/browse/NET-727
 
This changes only includes the mapping of `options` map in TFTPRequestPacket which would be towards implementing RFC2347. For my use case only requirement was to get the `blksize` (RFC2348) from the request packet and would like to move on to try my luck with implementing the RFC2347.



