### PR TITLE
[NET-736] Refactored testNET641 to use parameterized unit testing

### DIFF
--- a/src/test/java/org/apache/commons/net/util/SubnetUtilsTest.java
+++ b/src/test/java/org/apache/commons/net/util/SubnetUtilsTest.java
@@ -36,7 +36,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.FieldSource;
 
 /**
@@ -78,6 +77,12 @@ public class SubnetUtilsTest {
             ImmutablePair.of("192.168.0.1/31", 2L),
             ImmutablePair.of("192.168.0.1/32", 1L));
     // @formatter:on
+
+    private static final List<ImmutablePair<String, String>> VALUE_SETS_NET641 = Arrays.asList(
+            ImmutablePair.of("192.168.1.0/00", "0.0.0.0"),
+            ImmutablePair.of("192.168.1.0/30", "0.0.0.0"),
+            ImmutablePair.of("192.168.1.0/31", "0.0.0.0"),
+            ImmutablePair.of("192.168.1.0/32", "0.0.0.0"));
 
     @Test
     public void testAddresses() {
@@ -347,13 +352,10 @@ public class SubnetUtilsTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = {
-            "192.168.1.0/00, 0.0.0.0",
-            "192.168.1.0/30, 0.0.0.0",
-            "192.168.1.0/31, 0.0.0.0",
-            "192.168.1.0/32, 0.0.0.0"
-    })
-    public void testNET641(String cidrNotation, String address) {
+    @FieldSource("VALUE_SETS_NET641")
+    public void testNET641(final ImmutablePair<String, String> pair) {
+        final String cidrNotation = pair.getKey();
+        final String address = pair.getValue();
         assertFalse(new SubnetUtils(cidrNotation).getInfo().isInRange(address));
     }
 


### PR DESCRIPTION
[Referencing NET-736](https://issues.apache.org/jira/browse/NET-736)
Aim: 
Improve the test code by avoiding code duplication, improving maintainability, and enhancing readability. By converting the test into a parameterized unit test, we reduce boilerplate code, make it easier to extend by simply adding new input values, and improve debugging by clearly identifying which test case fails instead of searching through individual assertions.

```
@Test
    public void testNET641() {
        assertFalse(new SubnetUtils("192.168.1.0/00").getInfo().isInRange("0.0.0.0"));
        assertFalse(new SubnetUtils("192.168.1.0/30").getInfo().isInRange("0.0.0.0"));
        assertFalse(new SubnetUtils("192.168.1.0/31").getInfo().isInRange("0.0.0.0"));
        assertFalse(new SubnetUtils("192.168.1.0/32").getInfo().isInRange("0.0.0.0"));
    }
```
In the above in SubnetUtilsTest.java:
1. The same method call new SubnetUtils(...).getInfo().isInRange(...) is repeated multiple times with different inputs, making the test harder to maintain and extend.
2. When a test fails, JUnit only shows which assertion failed, but not which specific input caused the failure. 
3. Adding new test cases requires copying and pasting another assertFalse(...) statement instead of simply adding new data.

To accomplish this, I have retrofitted the test into a parameterized unit test. This reduces duplication, allows easy extension by simply adding new value sets, and makes debugging easier as it clearly indicates which test failed instead of requiring a search through individual assertions.
