### PR TITLE
Use hostname for FTPS EPSV data connection

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPClient.java
@@ -828,8 +828,18 @@ public class FTPClient extends FTP implements Configurable {
             throw new MalformedServerReplyException("Could not parse extended passive host information.\nServer Reply: " + reply);
         }
         // in EPSV mode, the passive host address is implicit
-        passiveHost = getRemoteAddress().getHostAddress();
+        passiveHost = resolveExtendedPassiveModeHost();
         passivePort = port;
+    }
+
+    /**
+     * Resolve the host for extended passive mode.
+     *
+     * @since 3.14.0
+     * @return the passive host
+     */
+    protected String resolveExtendedPassiveModeHost() {
+        return getRemoteAddress().getHostAddress();
     }
 
     /**

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -1119,5 +1119,14 @@ public class FTPSClient extends FTPClient {
             throw new SSLHandshakeException("Hostname doesn't match certificate");
         }
     }
+
+    @Override
+    protected String resolveExtendedPassiveModeHost() {
+        if (_socket_ instanceof SSLSocket) {
+            return ((SSLSocket) _socket_).getSession().getPeerHost();
+        } else {
+            return super.resolveExtendedPassiveModeHost();
+        }
+    }
 }
 

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -1128,5 +1128,13 @@ public class FTPSClient extends FTPClient {
             return super.resolveExtendedPassiveModeHost();
         }
     }
-}
+    /**
+     * Resolves the host for extended passive mode using the TLS session peer host,
+     * enabling TLS session reuse between the control and data connections.
+     *
+     * @since 3.14.0
+     * @return the passive host from the SSL session, or the default if not an SSL connection
+     */
+    @Override
+    protected String resolveExtendedPassiveModeHost() {
 

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -1120,21 +1120,15 @@ public class FTPSClient extends FTPClient {
         }
     }
 
-    @Override
-    protected String resolveExtendedPassiveModeHost() {
-        if (_socket_ instanceof SSLSocket) {
-            return ((SSLSocket) _socket_).getSession().getPeerHost();
-        } else {
-            return super.resolveExtendedPassiveModeHost();
-        }
-    }
     /**
      * Resolves the host for extended passive mode using the TLS session peer host,
      * enabling TLS session reuse between the control and data connections.
      *
-     * @since 3.14.0
      * @return the passive host from the SSL session, or the default if not an SSL connection
+     * @since 3.14.0
      */
     @Override
     protected String resolveExtendedPassiveModeHost() {
-
+        return _socket_ instanceof SSLSocket ? ((SSLSocket) _socket_).getSession().getPeerHost() : super.resolveExtendedPassiveModeHost();
+    }
+}


### PR DESCRIPTION
This allows FTPS to reuse the TLS session
of the FSTP command connection for the data connection.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->
