### PR TITLE
Reject CR/LF in SimpleSMTPHeader and SimpleNNTPHeader fields

### DIFF
--- a/src/main/java/org/apache/commons/net/nntp/SimpleNNTPHeader.java
+++ b/src/main/java/org/apache/commons/net/nntp/SimpleNNTPHeader.java
@@ -56,11 +56,18 @@ public class SimpleNNTPHeader {
      * @param subject The value of the {@code Subject:} header field. This should be the subject of the article.
      */
     public SimpleNNTPHeader(final String from, final String subject) {
-        this.from = from;
-        this.subject = subject;
+        this.from = validate(from);
+        this.subject = validate(subject);
         this.newsgroups = new StringBuilder();
         this.headerFields = new StringBuilder();
         this.newsgroupCount = 0;
+    }
+
+    private static String validate(final String value) {
+        if (value != null && (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0)) {
+            throw new IllegalArgumentException("Header value cannot contain CR or LF characters");
+        }
+        return value;
     }
 
     /**
@@ -76,6 +83,8 @@ public class SimpleNNTPHeader {
      * @param value       The value of the added header field.
      */
     public void addHeaderField(final String headerField, final String value) {
+        validate(headerField);
+        validate(value);
         headerFields.append(headerField);
         headerFields.append(": ");
         headerFields.append(value);
@@ -88,6 +97,7 @@ public class SimpleNNTPHeader {
      * @param newsgroup The newsgroup to add to the article's newsgroup distribution list.
      */
     public void addNewsgroup(final String newsgroup) {
+        validate(newsgroup);
         if (newsgroupCount++ > 0) {
             newsgroups.append(',');
         }

--- a/src/main/java/org/apache/commons/net/smtp/SimpleSMTPHeader.java
+++ b/src/main/java/org/apache/commons/net/smtp/SimpleSMTPHeader.java
@@ -66,11 +66,18 @@ public class SimpleSMTPHeader {
         if (from == null) {
             throw new IllegalArgumentException("From cannot be null");
         }
-        this.to = to;
-        this.from = from;
-        this.subject = subject;
+        this.to = validate(to);
+        this.from = validate(from);
+        this.subject = validate(subject);
         this.headerFields = new StringBuffer();
         this.cc = null;
+    }
+
+    private static String validate(final String value) {
+        if (value != null && (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0)) {
+            throw new IllegalArgumentException("Header value cannot contain CR or LF characters");
+        }
+        return value;
     }
 
     /**
@@ -79,6 +86,7 @@ public class SimpleSMTPHeader {
      * @param address The email address to add to the CC list.
      */
     public void addCC(final String address) {
+        validate(address);
         if (cc == null) {
             cc = new StringBuffer();
         } else {
@@ -101,6 +109,8 @@ public class SimpleSMTPHeader {
      * @param value       The value of the added header field.
      */
     public void addHeaderField(final String headerField, final String value) {
+        validate(headerField);
+        validate(value);
         if (!hasHeaderDate && "Date".equals(headerField)) {
             hasHeaderDate = true;
         }

--- a/src/test/java/org/apache/commons/net/nntp/SimpleNNTPHeaderTestCase.java
+++ b/src/test/java/org/apache/commons/net/nntp/SimpleNNTPHeaderTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.net.nntp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link SimpleNNTPHeader}.
+ */
+class SimpleNNTPHeaderTestCase {
+
+    @Test
+    void testRejectCarriageReturnInConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new SimpleNNTPHeader("foobar@foo.invalid", "Subject\rInjected: header"));
+    }
+
+    @Test
+    void testRejectLineFeedInAddHeaderField() {
+        final SimpleNNTPHeader header = new SimpleNNTPHeader("foobar@foo.invalid", "Just testing");
+        assertThrows(IllegalArgumentException.class, () -> header.addHeaderField("Organization", "Foobar, Inc.\nInjected: header"));
+    }
+
+    @Test
+    void testRejectLineFeedInAddNewsgroup() {
+        final SimpleNNTPHeader header = new SimpleNNTPHeader("foobar@foo.invalid", "Just testing");
+        assertThrows(IllegalArgumentException.class, () -> header.addNewsgroup("alt.test\nInjected: header"));
+    }
+
+    @Test
+    void testRejectLineFeedInConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new SimpleNNTPHeader("foobar@foo.invalid", "Subject\nInjected: header"));
+    }
+
+    @Test
+    void testToString() {
+        final SimpleNNTPHeader header = new SimpleNNTPHeader("foobar@foo.invalid", "Just testing");
+        header.addNewsgroup("alt.test");
+        header.addHeaderField("Organization", "Foobar, Inc.");
+        assertEquals("From: foobar@foo.invalid\nNewsgroups: alt.test\nSubject: Just testing\nOrganization: Foobar, Inc.\n\n", header.toString());
+    }
+}

--- a/src/test/java/org/apache/commons/net/smtp/SimpleSMTPHeaderTestCase.java
+++ b/src/test/java/org/apache/commons/net/smtp/SimpleSMTPHeaderTestCase.java
@@ -106,6 +106,28 @@ class SimpleSMTPHeaderTestCase {
     }
 
     @Test
+    void testRejectCarriageReturnInConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new SimpleSMTPHeader("from@here.invalid", "to@there.invalid", "Subject\rInjected: header"));
+    }
+
+    @Test
+    void testRejectLineFeedInAddCC() {
+        final SimpleSMTPHeader header = new SimpleSMTPHeader("from@here.invalid", null, null);
+        assertThrows(IllegalArgumentException.class, () -> header.addCC("cc@there.invalid\nBcc: victim@there.invalid"));
+    }
+
+    @Test
+    void testRejectLineFeedInAddHeaderField() {
+        final SimpleSMTPHeader header = new SimpleSMTPHeader("from@here.invalid", null, null);
+        assertThrows(IllegalArgumentException.class, () -> header.addHeaderField("X-Header1", "value 1\nX-Injected: value 2"));
+    }
+
+    @Test
+    void testRejectLineFeedInConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new SimpleSMTPHeader("from@here.invalid", "to@there.invalid", "Subject\nInjected: header"));
+    }
+
+    @Test
     void testToStringNoFrom() {
         assertThrows(IllegalArgumentException.class, () -> new SimpleSMTPHeader(null, null, null));
     }


### PR DESCRIPTION
Fuzzing a small contact-form mailer built on SimpleSMTPHeader turned this up. The subject/from/cc and addHeaderField values get appended straight into the generated header block, so an embedded LF injects arbitrary mail headers or a message body (CWE-93). SimpleNNTPHeader has the same gap in its From/Subject/Newsgroups and header sinks. Reject CR/LF in those values, like the existing null-From check.