### PR TITLE
Double leading dot on first line in DotTerminatedMessageWriter

### DIFF
--- a/src/main/java/org/apache/commons/net/io/DotTerminatedMessageWriter.java
+++ b/src/main/java/org/apache/commons/net/io/DotTerminatedMessageWriter.java
@@ -45,7 +45,9 @@ public final class DotTerminatedMessageWriter extends Writer {
     public DotTerminatedMessageWriter(final Writer output) {
         super(output);
         this.output = output;
-        this.state = NOTHING_SPECIAL_STATE;
+        // The message starts at the beginning of a line, so a leading dot on the
+        // first line must be doubled just like on any other line.
+        this.state = LAST_WAS_NL_STATE;
     }
 
     /**

--- a/src/test/java/org/apache/commons/net/io/DotTerminatedMessageWriterTest.java
+++ b/src/test/java/org/apache/commons/net/io/DotTerminatedMessageWriterTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.net.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+class DotTerminatedMessageWriterTest {
+
+    private String write(final String message) throws IOException {
+        final StringWriter sw = new StringWriter();
+        try (DotTerminatedMessageWriter writer = new DotTerminatedMessageWriter(sw)) {
+            writer.write(message);
+        }
+        return sw.toString();
+    }
+
+    @Test
+    void testDoubleLeadingDotOnFirstLine() throws IOException {
+        // A leading dot on the first line must be doubled, otherwise it is
+        // indistinguishable from the message terminator.
+        assertEquals("..\r\n.\r\n", write("."));
+        assertEquals("..hidden\r\n.\r\n", write(".hidden"));
+    }
+
+    @Test
+    void testFirstLineDotCannotTerminateEarly() throws IOException {
+        // "." CR LF as the first line would otherwise end the message and let the
+        // following text be read as protocol commands.
+        assertEquals("..\r\nINJECT\r\n.\r\n", write(".\r\nINJECT"));
+    }
+
+    @Test
+    void testDoubleLeadingDotOnLaterLine() throws IOException {
+        assertEquals("a\r\n..b\r\n.\r\n", write("a\r\n.b"));
+    }
+}


### PR DESCRIPTION
DotTerminatedMessageWriter starts in NOTHING_SPECIAL_STATE, so a period at the very start of the message isn't doubled even though it's the start of a line. A body beginning with "." then CRLF therefore ends the data phase early (SMTP DATA, NNTP POST, POP3), letting the following text be read as protocol commands. Initialize the state to LAST_WAS_NL_STATE so the message start is treated as a line start, matching the reader's un-stuffing.