### PR TITLE
reject CR/LF in IMAP quoteMailboxName

### DIFF
--- a/src/main/java/org/apache/commons/net/imap/IMAP.java
+++ b/src/main/java/org/apache/commons/net/imap/IMAP.java
@@ -106,6 +106,9 @@ public class IMAP extends SocketClient {
         if (input == null) { // Don't throw NPE here
             return null;
         }
+        if (input.indexOf('\r') >= 0 || input.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException("Mailbox name cannot contain CR or LF characters");
+        }
         if (input.isEmpty()) {
             return "\"\""; // return the string ""
         }

--- a/src/test/java/org/apache/commons/net/imap/IMAPTest.java
+++ b/src/test/java/org/apache/commons/net/imap/IMAPTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.net.imap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.stream.Stream;
@@ -86,6 +87,16 @@ class IMAPTest {
     @Test
     void testQuoteMailboxNameNullInput() {
         assertNull(IMAP.quoteMailboxName(null));
+    }
+
+    @Test
+    void testQuoteMailboxNameRejectsLineFeed() {
+        assertThrows(IllegalArgumentException.class, () -> IMAP.quoteMailboxName("INBOX\nA001 DELETE Sent"));
+    }
+
+    @Test
+    void testQuoteMailboxNameRejectsCarriageReturn() {
+        assertThrows(IllegalArgumentException.class, () -> IMAP.quoteMailboxName("INBOX\r\nA001 DELETE Sent"));
     }
 
     @Test


### PR DESCRIPTION
quoteMailboxName is what wraps mailbox names before they go into SELECT/CREATE/RENAME/COPY/etc., but it only quotes when the value has a space and never looks at line terminators. A name like `INBOX\r\nA001 DELETE "Sent"` is passed through untouched, so the CRLF ends the line and the rest is sent as a second IMAP command on the control connection. Rejecting CR/LF here, the same way SimpleSMTPHeader/SimpleNNTPHeader already do, closes that off without changing the existing quoting behavior.