### PR TITLE
Check parser type before instantiating class in DefaultFTPFileEntryParserFactory.createFileEntryParser()

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactory.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactory.java
@@ -119,11 +119,14 @@ public class DefaultFTPFileEntryParserFactory implements FTPFileEntryParserFacto
         if (JAVA_QUALIFIED_NAME_PATTERN.matcher(key).matches()) {
             try {
                 final Class<?> parserClass = Class.forName(key);
+                // Check the type before constructing, so a key resolving to some unrelated class
+                // (e.g. one taken from an untrusted SYST reply) is not instantiated for its side effects.
+                if (!FTPFileEntryParser.class.isAssignableFrom(parserClass)) {
+                    throw new ParserInitializationException(
+                            parserClass.getName() + " does not implement the interface " + FTPFileEntryParser.class.getCanonicalName());
+                }
                 try {
                     parser = (FTPFileEntryParser) parserClass.getConstructor().newInstance();
-                } catch (final ClassCastException e) {
-                    throw new ParserInitializationException(
-                            parserClass.getName() + " does not implement the interface " + FTPFileEntryParser.class.getCanonicalName(), e);
                 } catch (final Exception | LinkageError e) {
                     throw new ParserInitializationException("Error initializing parser", e);
                 }

--- a/src/main/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactory.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactory.java
@@ -118,9 +118,9 @@ public class DefaultFTPFileEntryParserFactory implements FTPFileEntryParserFacto
         // Is the key a possible class name?
         if (JAVA_QUALIFIED_NAME_PATTERN.matcher(key).matches()) {
             try {
-                final Class<?> parserClass = Class.forName(key);
-                // Check the type before constructing, so a key resolving to some unrelated class
-                // (e.g. one taken from an untrusted SYST reply) is not instantiated for its side effects.
+                // Load without initialising, so an unrelated class (e.g. one taken from an untrusted SYST reply)
+                // does not run its static initialiser before the type is checked.
+                final Class<?> parserClass = Class.forName(key, false, getClass().getClassLoader());
                 if (!FTPFileEntryParser.class.isAssignableFrom(parserClass)) {
                     throw new ParserInitializationException(
                             parserClass.getName() + " does not implement the interface " + FTPFileEntryParser.class.getCanonicalName());

--- a/src/test/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactoryTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactoryTest.java
@@ -30,12 +30,17 @@ import org.junit.jupiter.api.Test;
 
 class DefaultFTPFileEntryParserFactoryTest {
 
-    /** A non-parser class whose constructor records that it was invoked. */
+    /** Set from {@link ConstructorProbe}'s static initialiser; kept here so reading it does not initialise the probe. */
+    static boolean probeInitialized;
+
+    /** A non-parser class whose static initialiser records that the class was initialised. */
     public static final class ConstructorProbe {
-        static boolean instantiated;
+        static {
+            probeInitialized = true;
+        }
 
         public ConstructorProbe() {
-            instantiated = true;
+            // empty
         }
     }
 
@@ -166,9 +171,10 @@ class DefaultFTPFileEntryParserFactoryTest {
     @Test
     void testNonParserClassIsNotInstantiated() {
         final DefaultFTPFileEntryParserFactory factory = new DefaultFTPFileEntryParserFactory();
-        ConstructorProbe.instantiated = false;
+        probeInitialized = false;
         // A qualified class name can arrive from the server's SYST reply during auto-detection.
+        // Referencing the .class literal does not initialise the probe, so probeInitialized stays false unless the factory triggers it.
         assertThrows(ParserInitializationException.class, () -> factory.createFileEntryParser(ConstructorProbe.class.getName()));
-        assertFalse(ConstructorProbe.instantiated, "a class that is not an FTPFileEntryParser must not be instantiated");
+        assertFalse(probeInitialized, "a class that is not an FTPFileEntryParser must not be loaded with initialisation");
     }
 }

--- a/src/test/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactoryTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/DefaultFTPFileEntryParserFactoryTest.java
@@ -29,6 +29,16 @@ import org.apache.commons.net.ftp.FTPFileEntryParser;
 import org.junit.jupiter.api.Test;
 
 class DefaultFTPFileEntryParserFactoryTest {
+
+    /** A non-parser class whose constructor records that it was invoked. */
+    public static final class ConstructorProbe {
+        static boolean instantiated;
+
+        public ConstructorProbe() {
+            instantiated = true;
+        }
+    }
+
     private void checkParserClass(final FTPFileEntryParserFactory fact, final String key, final Class<?> expected) {
         final FTPClientConfig config = key == null ? new FTPClientConfig() : new FTPClientConfig(key);
         final FTPFileEntryParser parser = fact.createFileEntryParser(config);
@@ -104,7 +114,7 @@ class DefaultFTPFileEntryParserFactoryTest {
             factory.createFileEntryParser("org.apache.commons.net.ftp.parser.DefaultFTPFileEntryParserFactory");
             fail("Exception should have been thrown. \"DefaultFTPFileEntryParserFactory\" does not implement FTPFileEntryParser");
         } catch (final ParserInitializationException pie) {
-            assertTrue(pie.getCause() instanceof ClassCastException);
+            assertTrue(pie.getMessage().contains("does not implement the interface"), pie.getMessage());
         }
 
         try {
@@ -112,7 +122,7 @@ class DefaultFTPFileEntryParserFactoryTest {
             factory.createFileEntryParser("org.apache.commons.net.ftp.parser.FTPFileEntryParserFactory");
             fail("ParserInitializationException should have been thrown.");
         } catch (final ParserInitializationException pie) {
-            assertTrue(pie.getCause() instanceof ReflectiveOperationException, pie.getCause().toString());
+            assertTrue(pie.getMessage().contains("does not implement the interface"), pie.getMessage());
         }
         try {
             // Class exists, but is abstract
@@ -151,5 +161,14 @@ class DefaultFTPFileEntryParserFactoryTest {
 
         // Note: exact matching via config is the only way to generate NTFTPEntryParser and OS400FTPEntryParser
         // using DefaultFTPFileEntryParserFactory
+    }
+
+    @Test
+    void testNonParserClassIsNotInstantiated() {
+        final DefaultFTPFileEntryParserFactory factory = new DefaultFTPFileEntryParserFactory();
+        ConstructorProbe.instantiated = false;
+        // A qualified class name can arrive from the server's SYST reply during auto-detection.
+        assertThrows(ParserInitializationException.class, () -> factory.createFileEntryParser(ConstructorProbe.class.getName()));
+        assertFalse(ConstructorProbe.instantiated, "a class that is not an FTPFileEntryParser must not be instantiated");
     }
 }


### PR DESCRIPTION
**Untrusted class name from the SYST reply is instantiated during listing auto-detection**

When `FTPClient.listFiles()` runs without an explicit parser key or config it auto-detects the parser from the server's `SYST` reply, and `DefaultFTPFileEntryParserFactory` treats a reply that looks like a qualified class name as a class to load. It calls `Class.forName` and then `getConstructor().newInstance()`, only catching the `ClassCastException` afterwards, so the constructor and static initialiser of any class on the client's classpath run before the type is ever checked. A malicious or intercepted server can reply to `SYST` with the name of an arbitrary classpath class and have it built for its side effects (CWE-470). The impact is limited to classes already present, but it is still an unintended instantiation driven by remote input.

The type check is moved ahead of construction with `isAssignableFrom`, so unrelated classes are rejected before their constructor runs. The documented behaviour of passing your own parser class name is unchanged, since real parser classes still load and construct as before.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
