### PR TITLE
Run hostname verifier on FTPS data connection

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -299,6 +299,10 @@ public class FTPSClient extends FTPClient {
                 sslSocket.setEnabledProtocols(protocols);
             }
             sslSocket.startHandshake();
+
+            if (isClientMode && hostnameVerifier != null && !hostnameVerifier.verify(_hostname_, sslSocket.getSession())) {
+                throw new SSLHandshakeException("Hostname doesn't match certificate");
+            }
         }
 
         return socket;

--- a/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
+++ b/src/main/java/org/apache/commons/net/ftp/FTPSClient.java
@@ -299,7 +299,6 @@ public class FTPSClient extends FTPClient {
                 sslSocket.setEnabledProtocols(protocols);
             }
             sslSocket.startHandshake();
-
             if (isClientMode && hostnameVerifier != null && !hostnameVerifier.verify(_hostname_, sslSocket.getSession())) {
                 throw new SSLHandshakeException("Hostname doesn't match certificate");
             }

--- a/src/test/java/org/apache/commons/net/ftp/AbstractFtpsTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/AbstractFtpsTest.java
@@ -27,6 +27,8 @@ import java.net.SocketException;
 import java.net.URL;
 import java.time.Duration;
 
+import javax.net.ssl.HostnameVerifier;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.lang3.ThreadUtils;
@@ -141,6 +143,8 @@ public abstract class AbstractFtpsTest {
 
     private boolean endpointCheckingEnabled;
 
+    private HostnameVerifier hostnameVerifier;
+
     protected void assertClientCode(final FTPSClient client) {
         final int replyCode = client.getReplyCode();
         assertTrue(FTPReply.isPositiveCompletion(replyCode));
@@ -169,6 +173,9 @@ public abstract class AbstractFtpsTest {
         assertEquals(62, client.getDataTimeout().getSeconds());
         //
         client.setEndpointCheckingEnabled(endpointCheckingEnabled);
+        if (hostnameVerifier != null) {
+            client.setHostnameVerifier(hostnameVerifier);
+        }
         client.connect("localhost", SocketPort);
         //
         assertClientCode(client);
@@ -206,5 +213,9 @@ public abstract class AbstractFtpsTest {
 
     public void setEndpointCheckingEnabled(final boolean value) {
         this.endpointCheckingEnabled = value;
+    }
+
+    protected void setHostnameVerifier(final HostnameVerifier value) {
+        this.hostnameVerifier = value;
     }
 }

--- a/src/test/java/org/apache/commons/net/ftp/FTPSClientTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/FTPSClientTest.java
@@ -25,9 +25,11 @@ import java.io.IOException;
 import java.net.SocketException;
 import java.time.Instant;
 import java.util.Calendar;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -68,6 +70,31 @@ class FTPSClientTest extends AbstractFtpsTest {
         trace(">>testHasFeature");
         loginClient().disconnect();
         trace("<<testHasFeature");
+    }
+
+    @Test
+    @Timeout(TEST_TIMEOUT)
+    void testHostnameVerifierUsedForDataConnection() throws SocketException, IOException {
+        final AtomicInteger verifyCount = new AtomicInteger();
+        setHostnameVerifier((hostname, session) -> {
+            verifyCount.incrementAndGet();
+            return true;
+        });
+        try {
+            final FTPSClient client = loginClient();
+            try {
+                // control connection has already been verified during login
+                final int afterControl = verifyCount.get();
+                assertTrue(afterControl >= 1, "verifier should run for the control connection");
+                // listFiles opens a data connection, which must be verified too
+                assertNotNull(client.listFiles(""));
+                assertTrue(verifyCount.get() > afterControl, "verifier should run for the data connection");
+            } finally {
+                client.disconnect();
+            }
+        } finally {
+            setHostnameVerifier(null);
+        }
     }
 
     private void testListFiles(final String pathname) throws SocketException, IOException {


### PR DESCRIPTION
When a hostname verifier is installed through setHostnameVerifier, FTPSClient only runs it during the control-connection handshake in sslNegotiation; the data connection opened for each transfer completes its TLS handshake in _openDataConnection_ without ever calling the verifier. As the default trust manager only checks that the certificate is in date and not that the name matches, an in-path attacker on the data port can present any unexpired certificate and the transferred bytes are read or altered even though the caller asked for the server identity to be checked. This runs the same verifier against _hostname_ on the data socket after its handshake, so the data channel honours the check already applied to the control channel.