### PR TITLE
[NET-745] Clarify UnixFTPEntryParser trimLeadingSpaces in Javadoc

### DIFF
--- a/src/main/java/org/apache/commons/net/ftp/parser/UnixFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/UnixFTPEntryParser.java
@@ -31,10 +31,10 @@ import org.apache.commons.net.ftp.FTPFile;
  * interface.
  * </p>
  * <p>
- * By default, leading spaces in parsed file names are preserved because Unix file names can legitimately contain leading spaces. However, some FTP servers
- * (including IBM i / OS/400 systems returning Unix-style listings) pad the date column with extra spaces when showing a year instead of a time for
- * older entries. This can result in file names with an unintended leading space. Use the {@link #UnixFTPEntryParser(FTPClientConfig, boolean)} constructor
- * with {@code trimLeadingSpaces} set to {@code true} to remove leading spaces from file names.
+ * By default, leading spaces in parsed file names are preserved because Unix file names may legitimately begin with spaces. However, some FTP servers,
+ * including IBM i (formerly OS/400) systems that return Unix-style listings, pad the date field with additional spaces when displaying a year instead
+ * of a time for older entries. As a result, parsed file names may incorrectly include a leading space. To remove these unintended spaces, use the
+ * {@link #UnixFTPEntryParser(FTPClientConfig, boolean)} constructor with {@code trimLeadingSpaces} set to {@code true}.
  * </p>
  *
  * @see org.apache.commons.net.ftp.FTPFileEntryParser FTPFileEntryParser (for usage instructions)

--- a/src/main/java/org/apache/commons/net/ftp/parser/UnixFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/UnixFTPEntryParser.java
@@ -30,6 +30,12 @@ import org.apache.commons.net.ftp.FTPFile;
  * This class is based on the logic of Daniel Savarese's DefaultFTPListParser, but adapted to use regular expressions and to fit the new FTPFileEntryParser
  * interface.
  * </p>
+ * <p>
+ * By default, leading spaces in parsed file names are preserved because Unix file names can legitimately contain leading spaces. However, some FTP servers
+ * (including IBM i / OS/400 systems returning Unix-style listings) pad the date column with extra spaces when showing a year instead of a time for
+ * older entries. This can result in file names with an unintended leading space. Use the {@link #UnixFTPEntryParser(FTPClientConfig, boolean)} constructor
+ * with {@code trimLeadingSpaces} set to {@code true} to remove leading spaces from file names.
+ * </p>
  *
  * @see org.apache.commons.net.ftp.FTPFileEntryParser FTPFileEntryParser (for usage instructions)
  */


### PR DESCRIPTION
UnixFTPEntryParser preserves leading spaces in filenames by default, since Unix filenames can legitimately start with spaces. However, some FTP servers (including IBM i / OS/400 returning Unix-style listings) pad the date column with extra spaces when showing a year instead of a time for older entries, causing filenames to have an unintended leading space.

This was reported on the dev mailing list and tracked as NET-745. The trimLeadingSpaces constructor option (added in 3.4) fixes it, but the class Javadoc did not mention this behavior or the workaround.

This PR adds a paragraph to the class Javadoc explaining the issue and pointing to the trimLeadingSpaces constructor.

Resolves [NET-745](https://issues.apache.org/jira/browse/NET-745).