### PR TITLE
Force Gregorian calendar in FTP listing timestamp parsers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@ Supported protocols include Echo, Finger, FTP, NNTP, NTP, POP3(S), SMTP(S), Teln
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.ftpserver</groupId>
             <artifactId>ftpserver-core</artifactId>
             <version>1.2.1</version>

--- a/src/main/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParser.java
@@ -18,6 +18,7 @@
 package org.apache.commons.net.ftp.parser;
 
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 import org.apache.commons.net.ftp.FTPFile;
 
@@ -105,7 +106,7 @@ public class EnterpriseUnixFTPEntryParser extends RegexFTPFileEntryParserImpl {
                 // intentionally do nothing
             }
 
-            final Calendar cal = Calendar.getInstance();
+            final Calendar cal = new GregorianCalendar();
             cal.set(Calendar.MILLISECOND, 0);
             cal.set(Calendar.SECOND, 0);
             cal.set(Calendar.MINUTE, 0);

--- a/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
@@ -23,6 +23,7 @@ import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import org.apache.commons.net.ftp.Configurable;
@@ -294,6 +295,7 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
             final String year = Integer.toString(now.get(Calendar.YEAR));
             final String timeStampStrPlusYear = timestampStr + " " + year;
             final SimpleDateFormat hackFormatter = new SimpleDateFormat(recentDateFormat.toPattern() + " yyyy", recentDateFormat.getDateFormatSymbols());
+            hackFormatter.setCalendar(new GregorianCalendar());
             hackFormatter.setLenient(false);
             hackFormatter.setTimeZone(recentDateFormat.getTimeZone());
             final ParsePosition pp = new ParsePosition(0);
@@ -338,6 +340,7 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
             } else {
                 defaultDateFormat = new SimpleDateFormat(format);
             }
+            defaultDateFormat.setCalendar(new GregorianCalendar());
             defaultDateFormat.setLenient(false);
         } else {
             defaultDateFormat = null;
@@ -363,6 +366,7 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
             } else {
                 recentDateFormat = new SimpleDateFormat(format);
             }
+            recentDateFormat.setCalendar(new GregorianCalendar());
             recentDateFormat.setLenient(false);
         } else {
             recentDateFormat = null;

--- a/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImpl.java
@@ -292,7 +292,11 @@ public class FTPTimestampParserImpl implements FTPTimestampParser, Configurable 
             // all instances of short dates which are +- 6 months from current date.
             // TODO this won't always work for systems that use short dates +0/-12months
             // e.g. if today is Jan 1 2001 and the short date is Feb 29
-            final String year = Integer.toString(now.get(Calendar.YEAR));
+            // now is a clone of the caller's serverTime, which under some default locales (e.g. a Thai Buddhist calendar) is not Gregorian, so read the year
+            // through a Gregorian calendar at the same instant to keep the appended year Gregorian rather than 543 years out.
+            final GregorianCalendar gregorianNow = new GregorianCalendar(now.getTimeZone());
+            gregorianNow.setTimeInMillis(now.getTimeInMillis());
+            final String year = Integer.toString(gregorianNow.get(Calendar.YEAR));
             final String timeStampStrPlusYear = timestampStr + " " + year;
             final SimpleDateFormat hackFormatter = new SimpleDateFormat(recentDateFormat.toPattern() + " yyyy", recentDateFormat.getDateFormatSymbols());
             hackFormatter.setCalendar(new GregorianCalendar());

--- a/src/main/java/org/apache/commons/net/ftp/parser/MLSxEntryParser.java
+++ b/src/main/java/org/apache/commons/net/ftp/parser/MLSxEntryParser.java
@@ -111,10 +111,10 @@ public class MLSxEntryParser extends FTPFileEntryParserImpl {
         final SimpleDateFormat dateFormat;
         final boolean hasMillis;
         if (timestamp.contains(".")) {
-            dateFormat = new SimpleDateFormat("yyyyMMddHHmmss.SSS");
+            dateFormat = new SimpleDateFormat("yyyyMMddHHmmss.SSS", Locale.ROOT);
             hasMillis = true;
         } else {
-            dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+            dateFormat = new SimpleDateFormat("yyyyMMddHHmmss", Locale.ROOT);
             hasMillis = false;
         }
         final TimeZone gmtTimeZone = TimeZone.getTimeZone("GMT");

--- a/src/test/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParserTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParserTest.java
@@ -25,6 +25,7 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
+import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.net.ftp.FTPFile;
@@ -154,6 +155,26 @@ class EnterpriseUnixFTPEntryParserTest extends AbstractFTPParseTest {
         assertEquals(13, zDateTime.getHour());
         assertEquals(56, zDateTime.getMinute());
         assertEquals(0, zDateTime.getSecond());
+    }
+
+    /**
+     * A numeric year in a listing must be read as a Gregorian year regardless of the JVM default locale. Under a Thai locale the base Calendar is a Buddhist
+     * calendar, which would otherwise store the timestamp 543 years out.
+     */
+    @Test
+    void testAbsoluteYearWithNonGregorianDefaultLocale() {
+        final Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("th", "TH"));
+            final FTPFile ftpFile = getParser().parseFTPEntry("-C--E-----FTP A QUA1I1      18128       41 Apr 1 2014 QUADTEST3");
+            final TimeZone timeZone = TimeZone.getDefault();
+            final ZonedDateTime zDateTime = ZonedDateTime.ofInstant(ftpFile.getTimestampInstant(), ZoneId.of(timeZone.getID()));
+            assertEquals(2014, zDateTime.getYear());
+            assertEquals(Month.APRIL, zDateTime.getMonth());
+            assertEquals(1, zDateTime.getDayOfMonth());
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Override

--- a/src/test/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParserTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/EnterpriseUnixFTPEntryParserTest.java
@@ -25,12 +25,12 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
-import java.util.Locale;
 import java.util.TimeZone;
 
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPFileEntryParser;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Tests the EnterpriseUnixFTPEntryParser
@@ -162,19 +162,14 @@ class EnterpriseUnixFTPEntryParserTest extends AbstractFTPParseTest {
      * calendar, which would otherwise store the timestamp 543 years out.
      */
     @Test
+    @DefaultLocale(language = "th", country = "TH")
     void testAbsoluteYearWithNonGregorianDefaultLocale() {
-        final Locale defaultLocale = Locale.getDefault();
-        try {
-            Locale.setDefault(new Locale("th", "TH"));
-            final FTPFile ftpFile = getParser().parseFTPEntry("-C--E-----FTP A QUA1I1      18128       41 Apr 1 2014 QUADTEST3");
-            final TimeZone timeZone = TimeZone.getDefault();
-            final ZonedDateTime zDateTime = ZonedDateTime.ofInstant(ftpFile.getTimestampInstant(), ZoneId.of(timeZone.getID()));
-            assertEquals(2014, zDateTime.getYear());
-            assertEquals(Month.APRIL, zDateTime.getMonth());
-            assertEquals(1, zDateTime.getDayOfMonth());
-        } finally {
-            Locale.setDefault(defaultLocale);
-        }
+        final FTPFile ftpFile = getParser().parseFTPEntry("-C--E-----FTP A QUA1I1      18128       41 Apr 1 2014 QUADTEST3");
+        final TimeZone timeZone = TimeZone.getDefault();
+        final ZonedDateTime zDateTime = ZonedDateTime.ofInstant(ftpFile.getTimestampInstant(), ZoneId.of(timeZone.getID()));
+        assertEquals(2014, zDateTime.getYear());
+        assertEquals(Month.APRIL, zDateTime.getMonth());
+        assertEquals(1, zDateTime.getDayOfMonth());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImplTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImplTest.java
@@ -271,6 +271,32 @@ java.text.ParseException: Timestamp 'Mar 13 02:33' could not be parsed using a s
         }
     }
 
+    /**
+     * A numeric year from a server listing must be read as a Gregorian year regardless of the JVM default locale. Under a Thai locale the default
+     * SimpleDateFormat calendar is a Buddhist calendar, which would otherwise shift the parsed instant by 543 years.
+     */
+    @Test
+    void testParseTimestampWithNonGregorianDefaultLocale() throws ParseException {
+        final Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("th", "TH"));
+            final FTPTimestampParserImpl parser = new FTPTimestampParserImpl();
+            final FTPClientConfig config = new FTPClientConfig(FTPClientConfig.SYST_UNIX);
+            config.setDefaultDateFormatStr("yyyy-MM-dd HH:mm");
+            config.setRecentDateFormatStr("MMM d HH:mm");
+            config.setServerLanguageCode("en");
+            config.setServerTimeZoneId("GMT");
+            parser.configure(config);
+            final Calendar parsed = parser.parseTimestamp("2010-03-13 22:45", new GregorianCalendar());
+            final GregorianCalendar expected = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
+            expected.clear();
+            expected.set(2010, Calendar.MARCH, 13, 22, 45, 0);
+            assertEquals(expected.getTimeInMillis(), parsed.getTimeInMillis());
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
     @Test
     void testParseShortFutureDates1() throws Exception {
         final GregorianCalendar now = new GregorianCalendar(2001, Calendar.MAY, 30, 12, 0);

--- a/src/test/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImplTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/FTPTimestampParserImplTest.java
@@ -32,6 +32,7 @@ import java.util.TimeZone;
 import org.apache.commons.net.ftp.FTPClientConfig;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Test the FTPTimestampParser class.
@@ -276,25 +277,48 @@ java.text.ParseException: Timestamp 'Mar 13 02:33' could not be parsed using a s
      * SimpleDateFormat calendar is a Buddhist calendar, which would otherwise shift the parsed instant by 543 years.
      */
     @Test
+    @DefaultLocale(language = "th", country = "TH")
     void testParseTimestampWithNonGregorianDefaultLocale() throws ParseException {
-        final Locale defaultLocale = Locale.getDefault();
-        try {
-            Locale.setDefault(new Locale("th", "TH"));
-            final FTPTimestampParserImpl parser = new FTPTimestampParserImpl();
-            final FTPClientConfig config = new FTPClientConfig(FTPClientConfig.SYST_UNIX);
-            config.setDefaultDateFormatStr("yyyy-MM-dd HH:mm");
-            config.setRecentDateFormatStr("MMM d HH:mm");
-            config.setServerLanguageCode("en");
-            config.setServerTimeZoneId("GMT");
-            parser.configure(config);
-            final Calendar parsed = parser.parseTimestamp("2010-03-13 22:45", new GregorianCalendar());
-            final GregorianCalendar expected = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
-            expected.clear();
-            expected.set(2010, Calendar.MARCH, 13, 22, 45, 0);
-            assertEquals(expected.getTimeInMillis(), parsed.getTimeInMillis());
-        } finally {
-            Locale.setDefault(defaultLocale);
-        }
+        final FTPTimestampParserImpl parser = new FTPTimestampParserImpl();
+        final FTPClientConfig config = new FTPClientConfig(FTPClientConfig.SYST_UNIX);
+        config.setDefaultDateFormatStr("yyyy-MM-dd HH:mm");
+        config.setRecentDateFormatStr("MMM d HH:mm");
+        config.setServerLanguageCode("en");
+        config.setServerTimeZoneId("GMT");
+        parser.configure(config);
+        final Calendar parsed = parser.parseTimestamp("2010-03-13 22:45", new GregorianCalendar());
+        final GregorianCalendar expected = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
+        expected.clear();
+        expected.set(2010, Calendar.MARCH, 13, 22, 45, 0);
+        assertEquals(expected.getTimeInMillis(), parsed.getTimeInMillis());
+    }
+
+    /**
+     * A recent (short) date carries no year, so the parser appends the year taken from the supplied server time. When a caller builds that server time via
+     * {@link Calendar#getInstance()} under a Thai default locale it is a Buddhist calendar, so the appended year must be read through a Gregorian calendar or
+     * the parsed instant lands 543 years out.
+     */
+    @Test
+    @DefaultLocale(language = "th", country = "TH")
+    void testParseRecentTimestampWithNonGregorianDefaultLocale() throws ParseException {
+        final FTPTimestampParserImpl parser = new FTPTimestampParserImpl();
+        final FTPClientConfig config = new FTPClientConfig(FTPClientConfig.SYST_UNIX);
+        config.setDefaultDateFormatStr("yyyy-MM-dd HH:mm");
+        config.setRecentDateFormatStr("MMM d HH:mm");
+        config.setServerLanguageCode("en");
+        config.setServerTimeZoneId("GMT");
+        parser.configure(config);
+        // Calendar.getInstance() under a Thai default locale is a Buddhist calendar, mirroring how a caller builds the server time.
+        final Calendar serverTime = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        final GregorianCalendar serverInstant = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
+        serverInstant.clear();
+        serverInstant.set(2010, Calendar.JUNE, 1, 0, 0, 0);
+        serverTime.setTimeInMillis(serverInstant.getTimeInMillis());
+        final Calendar parsed = parser.parseTimestamp("Mar 13 22:45", serverTime);
+        final GregorianCalendar expected = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
+        expected.clear();
+        expected.set(2010, Calendar.MARCH, 13, 22, 45, 0);
+        assertEquals(expected.getTimeInMillis(), parsed.getTimeInMillis());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
@@ -26,6 +26,7 @@ import java.util.TimeZone;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPFileEntryParser;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  */
@@ -80,18 +81,13 @@ class MLSxEntryParserTest extends AbstractFTPParseTest {
      * Buddhist calendar that would read the year 543 years out.
      */
     @Test
+    @DefaultLocale(language = "th", country = "TH")
     void testParseGMTdateTimeWithNonGregorianDefaultLocale() {
-        final Locale defaultLocale = Locale.getDefault();
-        try {
-            Locale.setDefault(new Locale("th", "TH"));
-            final Calendar parsed = MLSxEntryParser.parseGMTdateTime("20100313224553");
-            final GregorianCalendar expected = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
-            expected.clear();
-            expected.set(2010, Calendar.MARCH, 13, 22, 45, 53);
-            assertEquals(expected.getTimeInMillis(), parsed.getTimeInMillis());
-        } finally {
-            Locale.setDefault(defaultLocale);
-        }
+        final Calendar parsed = MLSxEntryParser.parseGMTdateTime("20100313224553");
+        final GregorianCalendar expected = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
+        expected.clear();
+        expected.set(2010, Calendar.MARCH, 13, 22, 45, 53);
+        assertEquals(expected.getTimeInMillis(), parsed.getTimeInMillis());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
@@ -77,8 +77,8 @@ class MLSxEntryParserTest extends AbstractFTPParseTest {
     }
 
     /**
-     * The RFC 3659 time stamp is a numeric Gregorian date. Parsing it must not depend on the JVM default locale's calendar, which for e.g. a Thai locale is a
-     * Buddhist calendar that would read the year 543 years out.
+     * The RFC 3659 time stamp is a numeric Gregorian date. Parsing it must not depend on the JVM default locale's calendar, which, for example, 
+     * a Thai locale is a Buddhist calendar that would read the year 543 years out.
      */
     @Test
     @DefaultLocale(language = "th", country = "TH")

--- a/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
@@ -77,7 +77,7 @@ class MLSxEntryParserTest extends AbstractFTPParseTest {
     }
 
     /**
-     * The RFC 3659 time stamp is a numeric Gregorian date. Parsing it must not depend on the JVM default locale's calendar, which, for example, 
+     * The RFC 3659 time stamp is a numeric Gregorian date. Parsing it must not depend on the JVM default locale's calendar, which, for example,
      * a Thai locale is a Buddhist calendar that would read the year 543 years out.
      */
     @Test

--- a/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
+++ b/src/test/java/org/apache/commons/net/ftp/parser/MLSxEntryParserTest.java
@@ -16,6 +16,13 @@
  */
 package org.apache.commons.net.ftp.parser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+import java.util.TimeZone;
+
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPFileEntryParser;
 import org.junit.jupiter.api.Test;
@@ -66,6 +73,25 @@ class MLSxEntryParserTest extends AbstractFTPParseTest {
     @Override
     protected FTPFile nullFileOrNullDate(final FTPFile f) {
         return f;
+    }
+
+    /**
+     * The RFC 3659 time stamp is a numeric Gregorian date. Parsing it must not depend on the JVM default locale's calendar, which for e.g. a Thai locale is a
+     * Buddhist calendar that would read the year 543 years out.
+     */
+    @Test
+    void testParseGMTdateTimeWithNonGregorianDefaultLocale() {
+        final Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("th", "TH"));
+            final Calendar parsed = MLSxEntryParser.parseGMTdateTime("20100313224553");
+            final GregorianCalendar expected = new GregorianCalendar(TimeZone.getTimeZone("GMT"), Locale.ROOT);
+            expected.clear();
+            expected.set(2010, Calendar.MARCH, 13, 22, 45, 53);
+            assertEquals(expected.getTimeInMillis(), parsed.getTimeInMillis());
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Override


### PR DESCRIPTION
the FTP listing parsers build their SimpleDateFormat and Calendar objects without an explicit locale, so on a JVM whose default locale carries a non-Gregorian calendar (a Thai Buddhist calendar, or the ja_JP_JP imperial calendar) a server-supplied numeric year is read in the wrong era and the parsed instant ends up centuries out, 543 years under th_TH. this affects MLSxEntryParser.parseGMTdateTime (the RFC 3659 MLSD/MLST time stamp), the shared FTPTimestampParserImpl used by the unix/nt/vms/os400/etc parsers, and EnterpriseUnixFTPEntryParser, which sets the absolute year from a listing into a default-locale Calendar. forcing a Gregorian calendar at each construction site keeps parsing independent of the ambient locale; the added tests parse a listing under a Thai default locale and check the resulting instant, and fail on the current code.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
